### PR TITLE
Feature/rifex 21/adding confirmation message component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ notes.txt
 
 .coveralls.yml
 .nyc_output
+
+/old-ui/app/css/rif.css

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,6 +23,7 @@ const uglify = require('gulp-uglify-es').default
 const pify = require('pify')
 const gulpMultiProcess = require('gulp-multi-process')
 const endOfStream = pify(require('end-of-stream'))
+const concat = require('gulp-concat')
 
 function gulpParallel (...args) {
   return function spawnGulpChildProcess (cb) {
@@ -321,6 +322,8 @@ gulp.task('zip', gulp.parallel('zip:chrome', 'zip:firefox', 'zip:edge', 'zip:ope
 
 // high level tasks
 
+gulp.task('rifCss', watchRifCss)
+
 gulp.task('dev',
   gulp.series(
     'clean',
@@ -336,6 +339,7 @@ gulp.task('dev',
 gulp.task('dev:extension',
   gulp.series(
     'clean',
+    'rifCss',
     gulp.parallel(
       'dev:extension:js',
       'dev:copy',
@@ -358,6 +362,7 @@ gulp.task('dev:mascara',
 gulp.task('build',
   gulp.series(
     'clean',
+    'rifCss',
     gulpParallel(
       'build:extension:js',
       'build:mascara:js',
@@ -520,4 +525,18 @@ function bundleTask (opts) {
 
 function beep () {
   process.stdout.write('\x07')
+}
+
+function watchRifCss () {
+  watch('ui/app/rif/**/**.css', (event) => {
+    livereload.changed(event.path)
+    rifCss()
+  })
+  return rifCss()
+}
+
+function rifCss () {
+  return gulp.src('ui/app/rif/**/**.css')
+    .pipe(concat('rif.css'))
+    .pipe(gulp.dest('old-ui/app/css'))
 }

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -49,6 +49,7 @@ const ConfirmChangePassword = require('./components/confirm-change-password')
 const ethNetProps = require('eth-net-props')
 const { getMetaMaskAccounts } = require('../../ui/app/selectors')
 const { getNetworkID } = require('./util')
+const ConfirmationMessageComponent = require('../../ui/app/rif/components/confirmationMessage/confirmationMessage')
 
 module.exports = compose(
   withRouter,
@@ -98,6 +99,7 @@ function mapStateToProps (state) {
     frequentRpcList: state.metamask.frequentRpcList || [],
     featureFlags,
     suggestedTokens: state.metamask.suggestedTokens,
+    confirmationMessage: state.appState.confirmationMessage,
 
     // state needed to get account dropdown temporarily rendering from app bar
     identities,
@@ -107,7 +109,7 @@ function mapStateToProps (state) {
 }
 
 App.prototype.render = function () {
-  var props = this.props
+  const props = this.props
   const {
     currentView,
     isLoading,
@@ -123,6 +125,12 @@ App.prototype.render = function () {
   log.debug('Main ui render function')
 
   const confirmMsgTx = (props.currentView.name === 'confTx' && Object.keys(props.unapprovedTxs).length === 0)
+
+  let confirmationMessage = null
+
+  if (props.confirmationMessage) {
+    confirmationMessage = this.renderModal()
+  }
 
   return (
     h('.flex-column.full-height', {
@@ -147,9 +155,15 @@ App.prototype.render = function () {
         },
       }, [
         this.renderPrimary(),
+        confirmationMessage,
       ]),
     ])
   )
+}
+
+App.prototype.renderModal = function () {
+  log.debug('rendering confirmationMessage modal')
+  return h(ConfirmationMessageComponent, {key: 'confirmationMessage', message: this.props.confirmationMessage.message})
 }
 
 App.prototype.renderLoadingIndicator = function ({ isLoading, isLoadingNetwork, loadMessage }) {
@@ -305,14 +319,6 @@ App.prototype.renderPrimary = function () {
       log.debug('rendering info screen')
       return h(InfoScreen, {key: 'info'})
 
-      case 'payments':
-        log.debug('rendering payments screen')
-        return h(PaymentsScreen, {key: 'payments'})
-
-    case 'domains':
-      log.debug('rendering domains screen')
-      return h(DomainsScreen, {key: 'domains'})
-      
     case 'buyEth':
       log.debug('rendering buy ether screen')
       return h(BuyView, {key: 'buyEthView'})
@@ -365,6 +371,16 @@ App.prototype.renderPrimary = function () {
     case 'confirm-change-password':
       log.debug('rendering confirm password changing screen')
       return h(ConfirmChangePassword, {key: 'confirm-change-password'})
+
+    // RIF SECTION
+    case 'payments':
+      log.debug('rendering payments screen')
+      return h(PaymentsScreen, {key: 'payments'})
+
+    case 'domains':
+      log.debug('rendering domains screen')
+      return h(DomainsScreen, {key: 'domains'})
+
     default:
       log.debug('rendering default, account detail screen')
       return h(AccountDetailScreen, {key: 'account-detail'})

--- a/old-ui/css.js
+++ b/old-ui/css.js
@@ -18,6 +18,7 @@ var cssFiles = {
   'react-css': fs.readFileSync(path.join(__dirname, '..', 'node_modules', 'react-select', 'dist', 'react-select.css'), 'utf8'),
   'dropdowns.css': fs.readFileSync(path.join(__dirname, '/app/css/dropdowns.css'), 'utf8'),
   'app-bar.css': fs.readFileSync(path.join(__dirname, '/app/css/app-bar.css'), 'utf8'),
+  'rif.css': fs.readFileSync(path.join(__dirname, '/app/css/rif.css'), 'utf8'),
 }
 
 function bundleCss () {

--- a/package.json
+++ b/package.json
@@ -264,6 +264,7 @@
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-babel": "^8.0.0",
+    "gulp-concat": "^2.6.1",
     "gulp-json-editor": "^2.2.1",
     "gulp-livereload": "^4.0.0",
     "gulp-multi-process": "^1.3.1",

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -236,6 +236,22 @@ function reduceApp (state, action) {
         warning: null,
       })
 
+    case rifActions.SHOW_CONFIRMATION_MESSAGE:
+      return extend(appState, {
+        confirmationMessage: {
+          message: action.message,
+        },
+        transForward: false,
+        warning: null,
+      })
+
+    case rifActions.HIDE_CONFIRMATION_MESSAGE:
+      return extend(appState, {
+        confirmationMessage: null,
+        transForward: false,
+        warning: null,
+      })
+
     case actions.SHOW_ADD_TOKEN_PAGE:
       return extend(appState, {
         currentView: {

--- a/ui/app/rif/actions.js
+++ b/ui/app/rif/actions.js
@@ -1,19 +1,37 @@
-var rifActions = {
+const rifActions = {
   SHOW_DOMAINS_PAGE: 'SHOW_DOMAINS_PAGE',
   SHOW_PAYMENTS_PAGE: 'SHOW_PAYMENTS_PAGE',
+  SHOW_CONFIRMATION_MESSAGE: 'SHOW_CONFIRMATION_MESSAGE',
+  HIDE_CONFIRMATION_MESSAGE: 'HIDE_CONFIRMATION_MESSAGE',
   showDomainsPage,
   showPaymentsPage,
+  showConfirmationMessage,
+  hideConfirmationMessage,
 }
-module.exports = rifActions
 
 function showDomainsPage () {
-    return {
-      type: rifActions.SHOW_DOMAINS_PAGE,
-    }
+  return {
+    type: rifActions.SHOW_DOMAINS_PAGE,
+  }
 }
-  
+
 function showPaymentsPage () {
-return {
+  return {
     type: rifActions.SHOW_PAYMENTS_PAGE,
-    }
+  }
 }
+
+function showConfirmationMessage (message) {
+  return {
+    type: rifActions.SHOW_CONFIRMATION_MESSAGE,
+    message: message,
+  }
+}
+
+function hideConfirmationMessage () {
+  return {
+    type: rifActions.HIDE_CONFIRMATION_MESSAGE,
+  }
+}
+
+module.exports = rifActions

--- a/ui/app/rif/components/confirmationMessage/confirmationMessage.css
+++ b/ui/app/rif/components/confirmationMessage/confirmationMessage.css
@@ -1,0 +1,37 @@
+.confirmation-message {
+  display: flex;
+  flex-flow: column;
+  justify-content: space-between;
+  align-items: center;
+  text-align: center;
+}
+
+.confirmation-message>h1 {
+  font-weight: bold;
+  font-size: 1em;
+  text-transform: uppercase;
+  margin-bottom: 1em;
+}
+
+.confirmation-message>p {
+  margin: 1em;
+}
+
+.confirmation-buttons {
+  display: flex;
+  padding: 0.5em;
+}
+
+.confirmation-buttons>button {
+  margin: 0.5em;
+}
+
+.confirmation-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  max-width: 90%;
+  background: white;
+  padding: 1em;
+}

--- a/ui/app/rif/components/confirmationMessage/confirmationMessage.js
+++ b/ui/app/rif/components/confirmationMessage/confirmationMessage.js
@@ -1,0 +1,57 @@
+import React, {Component} from 'react'
+import {connect} from 'react-redux'
+import Modal from 'react-modal'
+import PropTypes from 'prop-types'
+import rifActions from '../../actions'
+
+class ConfirmationMessage extends Component {
+
+  static propTypes = {
+    message: PropTypes.object,
+    opened: PropTypes.bool,
+    dispatch: PropTypes.func,
+  }
+
+  afterOpenModal () {
+    // references are now sync'd and can be accessed.
+  }
+
+  closeModal () {
+    this.props.dispatch(rifActions.hideConfirmationMessage())
+  }
+
+  cancel () {
+    this.props.message.cancelCallback()
+    this.closeModal()
+  }
+
+  confirm () {
+    this.props.message.confirmCallback()
+    this.closeModal()
+  }
+
+  render () {
+    return (
+      <Modal
+        isOpen={true}
+        onAfterOpen={this.afterOpenModal}
+        onRequestClose={this.closeModal}
+        className="confirmation-modal">
+        <div className="confirmation-message">
+          <h1>{this.props.message.title}</h1>
+          <p>{this.props.message.body}</p>
+          <div className="confirmation-buttons">
+            <button onClick={this.cancel.bind(this)}>{this.props.message.cancelLabel}</button>
+            <button onClick={this.confirm.bind(this)}>{this.props.message.confirmLabel}</button>
+          </div>
+        </div>
+      </Modal>
+    )
+  }
+}
+function mapStateToProps (state) {
+  return {
+    dispatch: state.dispatch,
+  }
+}
+module.exports = connect(mapStateToProps)(ConfirmationMessage)


### PR DESCRIPTION
This PR adds the confirmation message component:

![imagen](https://user-images.githubusercontent.com/7540348/79248919-dee21d00-7e52-11ea-841b-7e505bcefd23.png)

Also add support for rif modular styling.

**Affects only the ui**

How to use it:

You can just use **rifActions.showConfirmationMessage** to display a confirmation message with a setup that look like this: 
```
const message = {
  title: 'Title',
  body: 'Some text that says what you need to confirm.',
  confirmLabel: 'Confirm',
  cancelLabel: 'Cancel',
  confirmCallback: () => {
    alert('You confirmed this!')
  },
  cancelCallback: () => {
    alert('You canceled this!')
  },
}
```
As you can see we have title to put a title to the box, a body to put a text to show in the body of the box, 2 labels, one for cancel and the other for confirmation and 2 callback functions to trigger when the user clicks on the cancel or confirm buttons. Here is a full example of use:
```
h('button', {
  onClick: () => {
    const message = {
      title: 'Title',
      body: 'Some text that says what you need to confirm.',
      confirmLabel: 'Confirm',
      cancelLabel: 'Cancel',
      confirmCallback: () => {
        alert('You confirmed this!')
      },
      cancelCallback: () => {
        alert('You canceled this!')
      },
    }
    return props.dispatch(rifActions.showConfirmationMessage(message))
  },
  style: { marginLeft: '10px' },
}, 'Open Box'),
```