### PR TITLE
RIFEX-65 Add nifty component for warning and errors

### DIFF
--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -363,7 +363,7 @@ App.prototype.renderPrimary = function () {
     // RIF SECTION
     case 'rif':
       log.debug('rendering rif screen')
-      return getPage(props.currentView);
+      return getPage(props.currentView, props.dispatch);
 
     default:
       log.debug('rendering default, account detail screen')

--- a/old-ui/app/components/app-bar/main-menu.js
+++ b/old-ui/app/components/app-bar/main-menu.js
@@ -90,8 +90,20 @@ const mapDispatchToProps = dispatch => {
     showConfigPage: () => dispatch(actions.showConfigPage()),
     lockMetamask: () => dispatch(actions.lockMetamask()),
     showInfoPage: () => dispatch(actions.showInfoPage()),
-    showDomainsPage: () => dispatch(rifActions.navigateTo(pageNames.rns.domains)),
-    showPaymentsPage: () => dispatch(rifActions.navigateTo(pageNames.rns.payments)),
+    showDomainsPage: () => dispatch(rifActions.navigateTo(
+      pageNames.rns.domains,
+      {
+        navBar: {
+          showTitle: false,
+        },
+      })),
+    showPaymentsPage: () => dispatch(rifActions.navigateTo(
+      pageNames.rns.payments,
+      {
+        navBar: {
+          title: 'Payments',
+        },
+      })),
   }
 }
 

--- a/old-ui/app/components/error.js
+++ b/old-ui/app/components/error.js
@@ -49,10 +49,16 @@ class ErrorComponent extends Component {
 	}
 }
 
+function mapStateToProps (state) {
+  return {
+    error: state.appState.warning,
+  }
+}
+
 function mapDispatchToProps (dispatch) {
 	return {
 		hideWarning: () => dispatch(actions.hideWarning()),
 	}
 }
 
-module.exports = connect(null, mapDispatchToProps)(ErrorComponent)
+module.exports = connect(mapStateToProps, mapDispatchToProps)(ErrorComponent)

--- a/old-ui/app/components/toast.js
+++ b/old-ui/app/components/toast.js
@@ -47,9 +47,12 @@ class ToastComponent extends Component {
 }
 
 function mapStateToProps (state) {
-	return {
-		toastMsg: state.appState.toastMsg,
-	}
+  if (state.appState.toast) {
+    return {
+      toastMsg: state.appState.toast.message,
+      isSuccess: state.appState.toast.success,
+    }
+  }
 }
 
 function mapDispatchToProps (dispatch) {

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -2215,10 +2215,13 @@ function hideWarning () {
   }
 }
 
-function displayToast (text) {
+function displayToast (text, success = true) {
   return {
     type: actions.DISPLAY_TOAST,
-    value: text,
+    value: {
+      message: text,
+      success,
+    },
   }
 }
 

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -652,7 +652,7 @@ function reduceApp (state, action) {
 
     case actions.DISPLAY_TOAST:
       return extend(appState, {
-        toastMsg: action.value,
+        toast: action.value,
         isLoading: false,
       })
 

--- a/ui/app/rif/actions.js
+++ b/ui/app/rif/actions.js
@@ -88,6 +88,7 @@ function canFinishRegistration (commitmentHash) {
       background.rif.rns.register.canFinishRegistration(commitmentHash, (error, result) => {
         dispatch(actions.hideLoadingIndication());
         if (error) {
+          dispatch(actions.displayWarning(error));
           return reject(error);
         }
         return resolve(result);
@@ -101,7 +102,11 @@ function finishRegistration (domainName) {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve) => {
       dispatch(actions.hideLoadingIndication());
-      background.rif.rns.register.finishRegistration(domainName);
+      background.rif.rns.register.finishRegistration(domainName, (error, result) => {
+        if (error) {
+          dispatch(actions.displayWarning(error));
+        }
+      });
       return resolve();
     });
   };
@@ -114,6 +119,7 @@ function getRegistrationCost (domainName, yearsToRegister) {
       dispatch(actions.hideLoadingIndication());
       background.rif.rns.register.getDomainCost(domainName, yearsToRegister, (error, result) => {
         if (error) {
+          dispatch(actions.displayWarning(error));
           return reject(error);
         }
         return resolve(result);
@@ -129,6 +135,7 @@ function getUnapprovedTransactions () {
       background.rif.rns.register.getUnapprovedTransactions((error, transactions) => {
         dispatch(actions.hideLoadingIndication());
         if (error) {
+          dispatch(actions.displayWarning(error));
           return reject(error);
         }
         return resolve(transactions);
@@ -144,6 +151,7 @@ function getSelectedAddress () {
       background.rif.rns.register.getSelectedAddress((error, selectedAddress) => {
         dispatch(actions.hideLoadingIndication());
         if (error) {
+          dispatch(actions.displayWarning(error));
           return reject(error);
         }
         return resolve(selectedAddress);

--- a/ui/app/rif/components/menu/index.js
+++ b/ui/app/rif/components/menu/index.js
@@ -19,31 +19,31 @@ class Menu extends Component {
     return [
       {
         label: 'Subdomains',
-        action: () => this.props.navigateTo(pageNames.rns.subdomains),
+        action: () => this.props.navigateTo(pageNames.rns.subdomains, 'Subdomains'),
       },
       {
         label: 'Renew Domain',
-        action: () => this.props.navigateTo(pageNames.rns.renew),
+        action: () => this.props.navigateTo(pageNames.rns.renew, 'Renew Domain'),
       },
       {
         label: 'Pay',
-        action: () => this.props.navigateTo(pageNames.rns.pay),
+        action: () => this.props.navigateTo(pageNames.rns.pay, 'Pay'),
       },
       {
         label: 'Sell it on MKP',
-        action: () => this.props.navigateTo(pageNames.rns.sellOnMKP),
+        action: () => this.props.navigateTo(pageNames.rns.sellOnMKP, 'Sell it on Marketplace'),
       },
       {
         label: 'Exchange Domain',
-        action: () => this.props.navigateTo(pageNames.rns.exchange),
+        action: () => this.props.navigateTo(pageNames.rns.exchange, 'Exchange Domain'),
       },
       {
         label: 'Transfer',
-        action: () => this.props.navigateTo(pageNames.rns.transfer),
+        action: () => this.props.navigateTo(pageNames.rns.transfer, 'Transfer Domain'),
       },
       {
         label: 'Lumino Channels',
-        action: () => this.props.navigateTo(pageNames.rns.luminoChannels),
+        action: () => this.props.navigateTo(pageNames.rns.luminoChannels, 'Lumino Channels'),
       },
     ];
   }
@@ -118,8 +118,15 @@ function mapStateToProps (state) {
 function mapDispatchToProps (dispatch) {
   return {
     showThis: (data) => dispatch(rifActions.showMenu(data)),
-    navigateTo: (screenName, params) => {
-      dispatch(rifActions.navigateTo(screenName, params));
+    navigateTo: (screenName, title, params) => {
+      dispatch(rifActions.navigateTo(screenName, {
+        ...params,
+        showDomainsSearch: true,
+        navBar: {
+          title,
+          backAction: () => dispatch(rifActions.navigateBack()),
+        },
+      }));
       dispatch(rifActions.hideMenu());
     },
   }

--- a/ui/app/rif/components/searchDomains.js
+++ b/ui/app/rif/components/searchDomains.js
@@ -67,6 +67,9 @@ const mapDispatchToProps = dispatch => {
     showDomainsDetailPage: (data) => dispatch(rifActions.navigateTo(pageNames.rns.domainsDetail, data)),
     showDomainRegisterPage: (domainName) => dispatch(rifActions.navigateTo(pageNames.rns.domainRegister, {
       domainName,
+      navBar: {
+        title: 'Domain Register',
+      },
     })),
     checkDomainAvailable: (domainName) => dispatch(rifActions.checkDomainAvailable(domainName)),
     displayWarning: (message) => dispatch(actions.displayWarning(message)),

--- a/ui/app/rif/pages/domainsDetailPage/domainsDetailPage.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainsDetailPage.js
@@ -1,24 +1,16 @@
-import React, { Component } from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronLeft } from '@fortawesome/free-solid-svg-icons'
+import {connect} from 'react-redux'
 import DomainsDetailActiveScreen from './domainDetailActive/domainDetailActive'
-import { SearchDomains } from '../../components'
-import rifActions from '../../actions'
-import {pageNames} from '../index'
 
 class DomainsDetailScreen extends Component {
 	static propTypes = {
 		status: PropTypes.string.isRequired,
-		goBack: PropTypes.func.isRequired,
 	}
 	render () {
 		const { status } = this.props
 		return (
 		<div className={'body'}>
-			<FontAwesomeIcon icon={faChevronLeft} className={'rif-back-button'} onClick={() => this.props.goBack()}/>
-			<SearchDomains />
 			{status === 'active' &&
 				<DomainsDetailActiveScreen />
 			}
@@ -40,9 +32,7 @@ function mapStateToProps (state) {
 }
 
 const mapDispatchToProps = dispatch => {
-	return {
-		goBack: () => dispatch(rifActions.navigateTo(pageNames.rns.domains)),
-	}
+	return {}
 }
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(DomainsDetailScreen)

--- a/ui/app/rif/pages/domainsPage/domainsPage.js
+++ b/ui/app/rif/pages/domainsPage/domainsPage.js
@@ -80,8 +80,7 @@ class DomainsScreen extends Component {
 
 DomainsScreen.propTypes = {
   showDomainsDetailPage: PropTypes.func.isRequired,
-  setAutoRenew: PropTypes.func.isRequired,
-  goHome: PropTypes.func.isRequired,
+  setAutoRenew: PropTypes.func.isRequired
 
 }
 
@@ -101,7 +100,6 @@ const mapDispatchToProps = dispatch => {
     })),
     setAutoRenew: (data) => {
     },
-    goHome: () => dispatch(actions.goHome()),
   }
 }
 

--- a/ui/app/rif/pages/domainsPage/domainsPage.js
+++ b/ui/app/rif/pages/domainsPage/domainsPage.js
@@ -1,102 +1,108 @@
-import React, { Component } from 'react'
+import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
-import { SearchDomains } from '../../components'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronLeft } from '@fortawesome/free-solid-svg-icons'
+import {connect} from 'react-redux'
 import actions from '../../../actions'
 import rifActions from '../../actions'
-import { mockDomains } from '../../test/mocks'
+import {mockDomains} from '../../test/mocks'
 import {pageNames} from '../index'
 
-function statusStyle(status){
-	switch(status){
-		case 'active':
-			return 'chiplet-status-active'
-		case 'pending':
-			return 'chiplet-status-pending'
-		case 'expired':
-			return 'chiplet-status-expired'
-		case 'expiring':
-			return 'chiplet-status-expiring'
-	}
+function statusStyle (status) {
+  switch (status) {
+    case 'active':
+      return 'chiplet-status-active'
+    case 'pending':
+      return 'chiplet-status-pending'
+    case 'expired':
+      return 'chiplet-status-expired'
+    case 'expiring':
+      return 'chiplet-status-expiring'
+  }
 }
 
 class DomainsScreen extends Component {
-	state = {
-		domains: [],
-	}
-	constructor(props) {
-		super(props);
-		//Mocking data
-		if(!localStorage.rnsDomains)
-			localStorage.setItem('rnsDomains', JSON.stringify(mockDomains))
-		if(localStorage.rnsDomains){
-			let domains = JSON.parse(localStorage.rnsDomains);
-			this.state = {
-				domains: domains,
-			}
-		}
-	}
-	navigateTo (url) {
-		global.platform.openWindow({ url })
-	}
+  state = {
+    domains: [],
+  }
 
-	chiplet = (data, id) => {
-		return <div id="chiplet" className={'chiplet'} key={id}>
-			<div className={'chiplet-body'}>
-				<div onClick={() => {this.props.showDomainsDetailPage(data)}} id="chipletTitle" className={'chiplet-title'}>
-					{data.domain}
-				</div>
-				<div id="chipletDescription" className={'chiplet-description'}>
-					<div id="chipletExpiration">
-						<span>Expires on: {data.expiration}</span>
-					</div>
-					<div id="chipletRenew">
-						<span>Auto-renew: <a href={this.props.setAutoRenew()}>{data.autoRenew ? "on" : "off"}</a></span>
-					</div>
-				</div>
-			</div>
-			<div className={'chiplet-status-wrapper ' + statusStyle(data.status)}>
-				<div id="chipletStatus" className={'chiplet-status-text'}>
-					{data.status}
-				</div>
-			</div>
-		</div>
-	}
+  constructor (props) {
+    super(props)
+    // Mocking data
+    if (!localStorage.rnsDomains) {
+      localStorage.setItem('rnsDomains', JSON.stringify(mockDomains))
+    }
+    if (localStorage.rnsDomains) {
+      let domains = JSON.parse(localStorage.rnsDomains)
+      this.state = {
+        domains: domains,
+      }
+    }
+  }
+
+  navigateTo (url) {
+    global.platform.openWindow({url})
+  }
+
+  chiplet = (data, id) => {
+    return <div id="chiplet" className={'chiplet'} key={id}>
+      <div className={'chiplet-body'}>
+        <div onClick={() => {
+          this.props.showDomainsDetailPage(data)
+        }} id="chipletTitle" className={'chiplet-title'}>
+          {data.domain}
+        </div>
+        <div id="chipletDescription" className={'chiplet-description'}>
+          <div id="chipletExpiration">
+            <span>Expires on: {data.expiration}</span>
+          </div>
+          <div id="chipletRenew">
+            <span>Auto-renew: <a href={this.props.setAutoRenew()}>{data.autoRenew ? 'on' : 'off'}</a></span>
+          </div>
+        </div>
+      </div>
+      <div className={'chiplet-status-wrapper ' + statusStyle(data.status)}>
+        <div id="chipletStatus" className={'chiplet-status-text'}>
+          {data.status}
+        </div>
+      </div>
+    </div>
+  }
 
   render () {
-	return (
-	  <div className={'body'}>
-		<FontAwesomeIcon icon={faChevronLeft} className={'rif-back-button'} onClick={() => this.props.goHome()}/>
-		<SearchDomains />
-		{this.state.domains.map((item, index) => {
-			return this.chiplet(item, index)
-		})}
-	  </div>
-	)
+    return (
+      <div className={'body'}>
+        {this.state.domains.map((item, index) => {
+          return this.chiplet(item, index)
+        })}
+      </div>
+    )
   }
 }
 
 DomainsScreen.propTypes = {
-	showDomainsDetailPage: PropTypes.func.isRequired,
-	setAutoRenew: PropTypes.func.isRequired,
-	goHome: PropTypes.func.isRequired,
+  showDomainsDetailPage: PropTypes.func.isRequired,
+  setAutoRenew: PropTypes.func.isRequired,
+  goHome: PropTypes.func.isRequired,
 
 }
 
 function mapStateToProps (state) {
   return {
-	  dispatch: state.dispatch,
-	}
+    dispatch: state.dispatch,
+  }
 }
 
 const mapDispatchToProps = dispatch => {
-	return {
-		showDomainsDetailPage: (data) => dispatch(rifActions.navigateTo(pageNames.rns.domainsDetail, data)),
-		setAutoRenew: (data) => {},
-		goHome: () => dispatch(actions.goHome()),
-	}
+  return {
+    showDomainsDetailPage: (data) => dispatch(rifActions.navigateTo(pageNames.rns.domainsDetail, {
+      ...data,
+      navBar: {
+        title: 'Domain Detail',
+      },
+    })),
+    setAutoRenew: (data) => {
+    },
+    goHome: () => dispatch(actions.goHome()),
+  }
 }
 
 module.exports = connect(mapStateToProps, mapDispatchToProps)(DomainsScreen)

--- a/ui/app/rif/pages/index.js
+++ b/ui/app/rif/pages/index.js
@@ -1,15 +1,19 @@
-import h from 'react-hyperscript';
-import DomainsScreen from './domainsPage/domainsPage';
-import PaymentsScreen from './paymentsPage/paymentsPage';
-import DomainsDetailScreen from './domainsDetailPage/domainsDetailPage';
-import Subdomains from './rns/subdomains';
-import Exchange from './rns/exchange';
-import LuminoChannels from './rns/lumino-channels';
-import Pay from './rns/pay';
-import Renew from './rns/renew';
-import SellOnMKP from './rns/sell-on-mkp';
-import Transfer from './rns/transfer';
-import DomainRegisterScreen from './rns/register';
+import DomainsScreen from './domainsPage/domainsPage'
+import PaymentsScreen from './paymentsPage/paymentsPage'
+import DomainsDetailScreen from './domainsDetailPage/domainsDetailPage'
+import Subdomains from './rns/subdomains'
+import Exchange from './rns/exchange'
+import LuminoChannels from './rns/lumino-channels'
+import Pay from './rns/pay'
+import Renew from './rns/renew'
+import SellOnMKP from './rns/sell-on-mkp'
+import Transfer from './rns/transfer'
+import DomainRegisterScreen from './rns/register'
+import React from 'react'
+import SearchDomains from '../components/searchDomains'
+import rifActions from '../actions'
+import ToastComponent from '../../../../old-ui/app/components/toast'
+import ErrorComponent from '../../../../old-ui/app/components/error'
 
 const pageNames = {
   rns: {
@@ -27,34 +31,87 @@ const pageNames = {
   },
 }
 
-function buildScreen (screenComponent, currentView) {
-  return h(screenComponent, {key: currentView.screenName})
+function buildScreen (screenComponent, context, dispatch) {
+  let navBar = null;
+  let searchDomains = null;
+
+  if (context.params.navBar) {
+    if (!context.params.navBar.title && context.params.navBar.showTitle) {
+      context.params.navBar.title = context.screenName;
+    }
+    if (!context.params.navBar.backAction && context.params.navBar.showBack) {
+      context.params.navBar.backAction = () => dispatch(rifActions.navigateBack());
+    }
+    let backButton = null;
+    if (context.params.navBar.showBack || context.params.navBar.backAction) {
+      backButton = (
+        <i onClick={(event) => {
+          context.params.navBar.backAction();
+        }} className="fa fa-arrow-left fa-lg cursor-pointer" style={{
+          position: 'absolute',
+          left: '30px',
+        }}/>
+      );
+    }
+    let title = null;
+    if (context.params.navBar.showTitle || context.params.navBar.title) {
+      title = (<h2>{context.params.navBar.title}</h2>);
+    }
+    navBar = (
+      <div className="section-title flex-row flex-center">
+        {backButton}
+        {title}
+      </div>
+    );
+  }
+
+  if (context.params.showDomainsSearch) {
+    searchDomains = (<SearchDomains/>);
+  }
+
+  const screenBody = (
+    <div className="flex-column flex-justify-center flex-grow select-none">
+      {screenComponent}
+    </div>
+  );
+
+  return (
+    <div className="flex-column flex-grow" style={{
+      maxWidth: '400px',
+    }}>
+      <ToastComponent />
+      <ErrorComponent />
+      {navBar}
+      {searchDomains}
+      {screenBody}
+    </div>
+  );
 }
 
-function getPage (context) {
+function getPage (context, dispatch) {
   switch (context.screenName) {
     case pageNames.rns.domains:
-      return buildScreen(DomainsScreen, context);
+      return buildScreen(<DomainsScreen/>, context, dispatch)
     case pageNames.rns.domainsDetail:
-      return buildScreen(DomainsDetailScreen, context);
+      return buildScreen(<DomainsDetailScreen/>, context, dispatch)
     case pageNames.rns.payments:
-      return buildScreen(PaymentsScreen, context);
+      return buildScreen(<PaymentsScreen/>, context, dispatch)
     case pageNames.rns.subdomains:
-      return buildScreen(Subdomains, context);
+      return buildScreen(<Subdomains/>, context, dispatch)
     case pageNames.rns.exchange:
-      return buildScreen(Exchange, context);
+      return buildScreen(<Exchange/>, context, dispatch)
     case pageNames.rns.luminoChannels:
-      return buildScreen(LuminoChannels, context);
+      return buildScreen(<LuminoChannels/>, context, dispatch)
     case pageNames.rns.pay:
-      return buildScreen(Pay, context);
+      return buildScreen(<Pay/>, context, dispatch)
     case pageNames.rns.renew:
-      return buildScreen(Renew, context);
+      return buildScreen(<Renew/>, context, dispatch)
     case pageNames.rns.sellOnMKP:
-      return buildScreen(SellOnMKP, context);
+      return buildScreen(<SellOnMKP/>, context, dispatch)
     case pageNames.rns.transfer:
-      return buildScreen(Transfer, context);
+      return buildScreen(<Transfer/>, context, dispatch)
     case pageNames.rns.domainRegister:
-      return buildScreen(DomainRegisterScreen, context);
+      return buildScreen(<DomainRegisterScreen/>, context, dispatch)
   }
 }
 

--- a/ui/app/rif/pages/paymentsPage/paymentsPage.js
+++ b/ui/app/rif/pages/paymentsPage/paymentsPage.js
@@ -1,46 +1,12 @@
-import { Component } from 'react';
-import h from 'react-hyperscript'
-import { connect } from 'react-redux'
-import actions from '../../../actions'
+import React, {Component} from 'react'
+import {connect} from 'react-redux'
 
 class PaymentsScreen extends Component {
   navigateTo (url) {
     global.platform.openWindow({ url })
   }
   render () {
-    return (
-      h('.flex-column.flex-grow', {
-        style: {
-          maxWidth: '400px',
-        },
-      }, [
-        // subtitle and nav
-        h('.section-title.flex-row.flex-center', [
-          h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
-            onClick: (event) => {
-              this.props.dispatch(actions.goHome())
-            },
-            style: {
-              position: 'absolute',
-              left: '30px',
-            },
-          }),
-          h('h2', 'Payments Screen'),
-        ]),
-        // main view
-        h('.flex-column.flex-justify-center.flex-grow.select-none', [
-          h('.flex-space-around', {
-            style: {
-              padding: '0 30px',
-            },
-          }, [
-            h('.info', [
-              h('div', 'Rif Payments'),
-            ]),
-          ]),
-        ]),
-      ])
-    )
+    return (<div>Payments Page</div>);
   }
 }
 function mapStateToProps (state) {

--- a/ui/app/rif/pages/rns/register/index.js
+++ b/ui/app/rif/pages/rns/register/index.js
@@ -3,11 +3,8 @@ import {connect} from 'react-redux'
 import PropTypes from 'prop-types'
 import rifActions from '../../../actions'
 import niftyActions from '../../../../actions'
-import {faChevronLeft} from '@fortawesome/free-solid-svg-icons'
-import {FontAwesomeIcon} from '@fortawesome/react-fontawesome'
-import {SearchDomains} from '../../../components'
-import {registrationTimeouts} from '../../../constants';
-import {pageNames} from '../../index';
+import {registrationTimeouts} from '../../../constants'
+import {pageNames} from '../../index'
 
 class DomainRegisterScreen extends Component {
 
@@ -18,7 +15,6 @@ class DomainRegisterScreen extends Component {
     getCost: PropTypes.func,
     showThis: PropTypes.func,
     dispatch: PropTypes.func,
-    goBack: PropTypes.func,
     currentStep: PropTypes.string,
     yearsToRegister: PropTypes.number,
     costInRif: PropTypes.number,
@@ -328,8 +324,6 @@ class DomainRegisterScreen extends Component {
     const registerButtons = this.getButtons(this.props.currentStep ? this.props.currentStep : 'available');
     return (
       <div className={'body'}>
-        <FontAwesomeIcon icon={faChevronLeft} className={'rif-back-button'} onClick={() => this.props.goBack()}/>
-        <SearchDomains />
         <div id="headerName" className={'domain-name'}>
           <div>{this.props.domainName}</div>
         </div>
@@ -356,9 +350,13 @@ function mapStateToProps (state) {
 
 const mapDispatchToProps = dispatch => {
   return {
-    goBack: () => dispatch(rifActions.navigateTo(pageNames.rns.domains)),
     dispatch: dispatch,
-    showThis: (data) => dispatch(rifActions.navigateTo(pageNames.rns.domainRegister, data)),
+    showThis: (data) => dispatch(rifActions.navigateTo(pageNames.rns.domainRegister, {
+      navBar: {
+        title: 'Domain Register',
+      },
+      ...data,
+    })),
     getCost: (domainName, yearsToRegister) => dispatch(rifActions.getRegistrationCost(domainName, yearsToRegister)),
     requestRegistration: (domainName, yearsToRegister) => dispatch(rifActions.requestDomainRegistration(domainName, yearsToRegister)),
     wait: (time) => dispatch(rifActions.waitUntil(time)),


### PR DESCRIPTION
This PR add the nifty warning and error components to our pages:
The warning/error component:
![imagen](https://user-images.githubusercontent.com/7540348/80763597-3f40b200-8b15-11ea-8b6c-04dcbd20805f.png)
The toast or message component:
![imagen](https://user-images.githubusercontent.com/7540348/80763741-96468700-8b15-11ea-853c-6d7672577f27.png)


In this PR we are:

* Fixing a bug on the nifty warning component
* Fixing a bug on the nifty error component
* Adding both to our page reducer
* Adding the navbar for our pages
* Adding support for navigation on the navbar
* Updating our screens to support navigation bar

This affects the ui for nifty and rif components