### PR TITLE
Feature/rifex 46/view subdomain

### DIFF
--- a/app/scripts/controllers/rif/constants/index.js
+++ b/app/scripts/controllers/rif/constants/index.js
@@ -1,5 +1,11 @@
 import {rns} from './rns'
 
+const global = {
+  TRANSACTION_STATUS_OK: '0x1',
+  TRANSACTION_STATUS_FAIL: '0x0',
+}
+
 export {
   rns,
+  global,
 }

--- a/app/scripts/controllers/rif/index.js
+++ b/app/scripts/controllers/rif/index.js
@@ -1,5 +1,6 @@
-import RnsManager from './rns';
-import Web3 from 'web3';
+import RnsManager from './rns'
+import Web3 from 'web3'
+import ComposableObservableStore from './../../lib/ComposableObservableStore'
 
 /**
  * RIF Controller
@@ -27,38 +28,24 @@ export default class RifController {
       throw new Error('TransactionController has to be present');
     }
 
-    if (!props.metamaskStore) {
-      throw new Error('MetaMask store has to be present');
-    }
-
-    if (!props.memoryStore) {
-      throw new Error('Memory Store has to be present');
-    }
-
-    this.metamaskStore = props.metamaskStore;
-    this.memoryStore = props.memoryStore;
     this.preferencesController = props.preferencesController;
     this.networkController = props.networkController;
     this.transactionController = props.transactionController;
     this.web3 = new Web3(this.networkController._provider);
 
+    const initState = props.initState || {};
+
     this.rnsManager = new RnsManager({
+      initState: initState.RnsManager,
       preferencesController: this.preferencesController,
       networkController: this.networkController,
       transactionController: this.transactionController,
       web3: this.web3,
     });
 
-    const metamaskStoreConfig = {
-      ...this.metamaskStore.config,
-      RifController: this.rnsManager.store,
-    };
-    const memoryStoreConfig = {
-      ...this.memoryStore.config,
+    this.store = new ComposableObservableStore(props.initState, {
       RnsManager: this.rnsManager.store,
-    };
-    this.metamaskStore.updateStructure(metamaskStoreConfig);
-    this.memoryStore.updateStructure(memoryStoreConfig);
+    });
   }
 
   /**

--- a/app/scripts/controllers/rif/rns/index.js
+++ b/app/scripts/controllers/rif/rns/index.js
@@ -1,10 +1,11 @@
-import RnsRegister from './register';
-import RnsResolver from './resolver';
-import RnsTransfer from './transfer';
-import rifConfig from './../../../../../rif.config';
-import RNS from './abis/RNS.json';
-import RIF from './abis/RIF.json';
-import ObservableStore from 'obs-store';
+import RnsRegister from './register'
+import RnsResolver from './resolver'
+import RnsTransfer from './transfer'
+import rifConfig from './../../../../../rif.config'
+import RNS from './abis/RNS.json'
+import RIF from './abis/RIF.json'
+import extend from 'xtend'
+import ObservableStore from 'obs-store'
 
 /**
  * This class encapsulates all the RNS operations, it initializes and call to all the delegates and exposes their operations.
@@ -30,11 +31,12 @@ export default class RnsManager {
     this.rifConfig = rifConfig;
     this.rnsContractInstance = this.web3.eth.contract(RNS).at(this.rifConfig.rns.contracts.rns);
     this.rifContractInstance = this.web3.eth.contract(RIF).at(this.rifConfig.rns.contracts.rif);
-    this.store = new ObservableStore({
+    const initState = extend({
       register: {},
       resolver: {},
       transfer: {},
-    });
+    }, props.initState);
+    this.store = new ObservableStore(initState);
 
     this.rnsRegister = new RnsRegister({
       web3: this.web3,

--- a/app/scripts/controllers/rif/rns/register/index.js
+++ b/app/scripts/controllers/rif/rns/register/index.js
@@ -2,6 +2,7 @@ import FIFSRegistrar from '../abis/FIFSRegistrar.json'
 import RnsJsDelegate from '../rnsjs-delegate'
 import web3Utils from 'web3-utils';
 import {generateRandomSecret, numberToUint32, utf8ToHexString} from '../../utils/rns'
+import {namehash} from '@rsksmart/rns/lib/utils'
 
 /**
  * This is a delegate to manage all the RNS register operations.
@@ -19,6 +20,7 @@ export default class RnsRegister extends RnsJsDelegate {
       finishRegistration: this.bindOperation(this.finishRegistration, this),
       canFinishRegistration: this.bindOperation(this.canFinishRegistration, this),
       getDomainCost: this.bindOperation(this.getDomainCost, this),
+      createSubdomain: this.bindOperation(this.createSubdomain, this),
       ...rnsJsApi,
     }
   }
@@ -30,7 +32,7 @@ export default class RnsRegister extends RnsJsDelegate {
    * @returns {Promise<string>} commitment that helps is to check if you can finish registration or you still have to wait.
    */
   requestRegistration (domainName, yearsToRegister) {
-    const cleanDomainName = this.cleanDomainFromRskPrefix(domainName);
+    const cleanDomainName = this.cleanDomainFromRskSuffix(domainName);
     const domainHash = web3Utils.sha3(cleanDomainName);
     const secret = generateRandomSecret();
     return new Promise((resolve, reject) => {
@@ -69,7 +71,7 @@ export default class RnsRegister extends RnsJsDelegate {
    * @returns registration cost in RIF (wei)
    */
   getDomainCost (domainName, yearsToRegister) {
-    const cleanDomainName = this.cleanDomainFromRskPrefix(domainName);
+    const cleanDomainName = this.cleanDomainFromRskSuffix(domainName);
     return this.call(this.fifsAddrRegistrarInstance, 'price', [cleanDomainName, 0, yearsToRegister]);
   }
 
@@ -96,7 +98,7 @@ export default class RnsRegister extends RnsJsDelegate {
    * @returns {Promise<void>}
    */
   finishRegistration (domainName) {
-    const cleanDomainName = this.cleanDomainFromRskPrefix(domainName);
+    const cleanDomainName = this.cleanDomainFromRskSuffix(domainName);
     const state = this.getStoreState();
     const registerByAddress = state.register[this.address];
     if (registerByAddress) {
@@ -178,6 +180,34 @@ export default class RnsRegister extends RnsJsDelegate {
     const dataName = utf8ToHexString(name);
 
     return `${dataSignature}${dataOwner}${dataSecret}${dataDuration}${dataName}`;
+  }
+
+  /**
+   * Overrides the parent operation because rns-js is failing on this, we invoke the contract directly.
+   */
+  createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddress) {
+    domainName = this.addRskSuffix(domainName);
+    if (!ownerAddress) {
+      ownerAddress = this.address;
+    }
+    const node = namehash(domainName);
+    const label = web3Utils.sha3(subdomain);
+    const result = this.send(this.rnsContractInstance, 'setSubnodeOwner', [node, label, ownerAddress])
+    result.then(transactionReceipt => {
+      if (transactionReceipt) {
+        const subdomains = this.getSubdomains(domainName);
+        subdomains.push({
+          domainName,
+          name: subdomain,
+          ownerAddress,
+          parentOwnerAddress,
+        });
+        this.updateSubdomains(domainName, subdomains);
+      }
+    }).catch(error => {
+      console.log(error);
+    });
+    return result;
   }
 
 }

--- a/app/scripts/controllers/rif/rns/rns-delegate.js
+++ b/app/scripts/controllers/rif/rns/rns-delegate.js
@@ -1,5 +1,6 @@
 const nodeify = require('../../../lib/nodeify')
 import extend from 'xtend'
+import {global} from '../constants'
 /**
  * Delegate class to encapsulate all the logic related to delegates.
  */
@@ -94,11 +95,20 @@ export default class RnsDelegate {
     if (contractInstance && methodName) {
       if (contractInstance[methodName]) {
         return new Promise((resolve, reject) => {
-          contractInstance[methodName].sendTransaction(...parameters, transactionOptions, (error, result) => {
+          contractInstance[methodName].sendTransaction(...parameters, transactionOptions, (error, transactionHash) => {
             if (error) {
               reject(error);
             }
-            resolve(result);
+            this.web3.eth.getTransactionReceipt(transactionHash, (error, transactionReceipt) => {
+              if (error) {
+                reject(error);
+              }
+              if (transactionReceipt && transactionReceipt.status === global.TRANSACTION_STATUS_OK) {
+                resolve(transactionReceipt);
+              } else {
+                reject(transactionReceipt);
+              }
+            });
           })
         });
       }

--- a/app/scripts/controllers/rif/rns/rns-delegate.js
+++ b/app/scripts/controllers/rif/rns/rns-delegate.js
@@ -113,8 +113,18 @@ export default class RnsDelegate {
    * @param domainName the domain name to clear.
    * @returns the cleared domain name
    */
-  cleanDomainFromRskPrefix (domainName) {
+  cleanDomainFromRskSuffix (domainName) {
     return (domainName && domainName.indexOf('.rsk') !== -1) ? domainName.replace('.rsk', '') : domainName;
+  }
+
+  /**
+   * Returns the domain name with .rsk, this is because rns-js expects domains with .rsk suffix and the top level call
+   * has for example infuy without the .rsk
+   * @param domainName the domain name to change.
+   * @returns the domain name with the rsk suffix
+   */
+  addRskSuffix (domainName) {
+    return (domainName && domainName.indexOf('.rsk') === -1) ? (domainName + '.rsk') : domainName;
   }
 
   /**

--- a/app/scripts/controllers/rif/rns/rnsjs-delegate.js
+++ b/app/scripts/controllers/rif/rns/rnsjs-delegate.js
@@ -48,6 +48,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @returns {Promise<string>} the address resolution
    */
   getDomainAddress (domainName, chainId) {
+    domainName = this.addRskSuffix(domainName);
     return this.rnsJs.addr(domainName, chainId);
   }
 
@@ -67,6 +68,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @returns {Promise<>} TransactionReceipt
    */
   setAddressToDomain (domainName, address) {
+    domainName = this.addRskSuffix(domainName);
     return this.rnsJs.setAddr(domainName, address);
   }
 
@@ -77,6 +79,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @returns {Promise<>} TransactionReceipt
    */
   setDomainResolver (domainName, resolver) {
+    domainName = this.addRskSuffix(domainName);
     return this.rnsJs.setResolver(domainName, resolver);
   }
 
@@ -87,6 +90,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * or an array of available domains under possible TLDs if the parameter is a label
    */
   isDomainAvailable (domainName) {
+    domainName = this.addRskSuffix(domainName);
     return this.rnsJs.available(domainName);
   }
 
@@ -97,6 +101,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @returns {Promise<boolean>} true if available, false if not
    */
   isSubdomainAvailable (domainName, subdomain) {
+    domainName = this.addRskSuffix(domainName);
     return this.rnsJs.subdomains.available(domainName, subdomain);
   }
 
@@ -109,6 +114,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @returns {Promise<>}
    */
   setSubdomainOwner (domainName, subdomain, ownerAddress) {
+    domainName = this.addRskSuffix(domainName);
     const result = this.rnsJs.subdomains.setOwner(domainName, subdomain, ownerAddress);
     result.then(transactionReceipt => {
       if (transactionReceipt) {
@@ -136,6 +142,10 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @returns {Promise<>} TransactionReceipt of the latest transaction
    */
   createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddress) {
+    domainName = this.addRskSuffix(domainName);
+    if (!ownerAddress) {
+      ownerAddress = this.address;
+    }
     const result = this.rnsJs.subdomains.create(domainName, subdomain, ownerAddress, parentOwnerAddress);
     result.then(transactionReceipt => {
       if (transactionReceipt) {
@@ -148,7 +158,9 @@ export default class RnsJsDelegate extends RnsDelegate {
         });
         this.updateSubdomains(domainName, subdomains);
       }
-    })
+    }).catch(error => {
+      console.log(error);
+    });
     return result;
   }
 
@@ -158,6 +170,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @returns the subdomains array
    */
   getSubdomains (domainName) {
+    domainName = this.addRskSuffix(domainName);
     const state = this.getStateForContainer(rns.storeContainers.register);
     if (!state || !state.subdomains || !state.subdomains[domainName]) {
       return [];
@@ -171,6 +184,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @returns the subdomains under the domain name
    */
   getSubdomainsForDomain (domainName) {
+    domainName = this.addRskSuffix(domainName);
     return Promise.resolve(this.getSubdomains(domainName));
   }
 
@@ -180,6 +194,7 @@ export default class RnsJsDelegate extends RnsDelegate {
    * @param subdomains the subdomains under the domain name
    */
   updateSubdomains (domainName, subdomains) {
+    domainName = this.addRskSuffix(domainName);
     let state = this.getStateForContainer(rns.storeContainers.register);
     if (!state) {
       state = {

--- a/app/scripts/controllers/rif/rns/rnsjs-delegate.js
+++ b/app/scripts/controllers/rif/rns/rnsjs-delegate.js
@@ -117,7 +117,7 @@ export default class RnsJsDelegate extends RnsDelegate {
     domainName = this.addRskSuffix(domainName);
     const result = this.rnsJs.subdomains.setOwner(domainName, subdomain, ownerAddress);
     result.then(transactionReceipt => {
-      if (transactionReceipt) {
+      if (transactionReceipt && transactionReceipt.status === true) {
         const subdomains = this.getSubdomains(domainName);
         const foundSubdomain = subdomains.find(sd => sd.name === subdomain);
         foundSubdomain.ownerAddress = ownerAddress;
@@ -150,7 +150,7 @@ export default class RnsJsDelegate extends RnsDelegate {
     }
     const result = this.rnsJs.subdomains.create(domainName, subdomain, ownerAddress, parentOwnerAddress);
     result.then(transactionReceipt => {
-      if (transactionReceipt) {
+      if (transactionReceipt && transactionReceipt.status === true) {
         const subdomains = this.getSubdomains(domainName);
         subdomains.push({
           domainName,

--- a/app/scripts/controllers/rif/rns/rnsjs-delegate.js
+++ b/app/scripts/controllers/rif/rns/rnsjs-delegate.js
@@ -172,10 +172,10 @@ export default class RnsJsDelegate extends RnsDelegate {
   getSubdomains (domainName) {
     domainName = this.addRskSuffix(domainName);
     const state = this.getStateForContainer(rns.storeContainers.register);
-    if (!state || !state.subdomains || !state.subdomains[domainName]) {
+    if (!state || !state.domains || !state.domains[domainName] || !state.domains[domainName].subdomains) {
       return [];
     }
-    return state.subdomains[domainName];
+    return state.domains[domainName].subdomains;
   }
 
   /**
@@ -198,10 +198,21 @@ export default class RnsJsDelegate extends RnsDelegate {
     let state = this.getStateForContainer(rns.storeContainers.register);
     if (!state) {
       state = {
+        domains: [],
+      };
+    }
+    if (!state.domains) {
+      state.domains = {};
+    }
+    if (!state.domains[domainName]) {
+      state.domains[domainName] = {
         subdomains: [],
       };
     }
-    state.subdomains[domainName] = subdomains;
+    if (!state.domains[domainName].subdomains) {
+      state.domains[domainName].subdomains = [];
+    }
+    state.domains[domainName].subdomains = subdomains;
     this.updateStateForContainer(rns.storeContainers.register, state);
   }
 

--- a/app/scripts/controllers/rif/rns/rnsjs-delegate.js
+++ b/app/scripts/controllers/rif/rns/rnsjs-delegate.js
@@ -143,8 +143,10 @@ export default class RnsJsDelegate extends RnsDelegate {
    */
   createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddress) {
     domainName = this.addRskSuffix(domainName);
-    if (!ownerAddress) {
-      ownerAddress = this.address;
+    if (!ownerAddress && !parentOwnerAddress) {
+      return Promise.reject('You need to specify ownerAddress or parentOwnerAddress');
+    } else if (!ownerAddress) {
+      ownerAddress = parentOwnerAddress;
     }
     const result = this.rnsJs.subdomains.create(domainName, subdomain, ownerAddress, parentOwnerAddress);
     result.then(transactionReceipt => {

--- a/app/scripts/controllers/rif/transaction-listener.js
+++ b/app/scripts/controllers/rif/transaction-listener.js
@@ -1,0 +1,74 @@
+import EventEmitter from 'safe-event-emitter'
+import {global} from './constants'
+
+/**
+ * Listener for pending mining transactions to handle events
+ */
+export class TransactionListener extends EventEmitter {
+  constructor (props) {
+    super();
+    this.web3 = props.web3;
+    this.transactionId = props.transactionId;
+    this.transactionHash = props.transactionHash;
+    this.transactionController = props.transactionController;
+    this.transactionMined = false;
+  }
+
+  /**
+   * Start listening for mined transactions to filter by our transaction if it's available
+   * If the transaction is there we get the receipt and we emit events depending on what the result is.
+   * @returns {TransactionListener}
+   */
+  listen () {
+    this.transactionController.on(`tx:status-update`, (txId, status) => {
+      if (this.transactionId === txId) {
+        this.transactionMined = true;
+        if (status === 'confirmed' || status === 'failed') {
+          this.getTransactionReceipt().then(transactionReceipt => {
+            if (transactionReceipt &&
+              (transactionReceipt.status === true || transactionReceipt.status === global.TRANSACTION_STATUS_OK)) {
+              this.emit('transactionSuccess', transactionReceipt);
+            } else {
+              this.emit('transactionFailed', transactionReceipt);
+            }
+          });
+        }
+      }
+    });
+    return this;
+  }
+
+  /**
+   * Gets the transaction receipt if it's available at the time.
+   * @returns {Promise<TransactionReceipt>}
+   */
+  getTransactionReceipt () {
+    if (this.transactionMined) {
+      return new Promise((resolve, reject) => {
+        this.web3.eth.getTransactionReceipt(this.transactionHash, (error, transactionReceipt) => {
+          if (error) {
+            reject(error);
+          }
+          resolve(transactionReceipt);
+        });
+      });
+    }
+    return Promise.reject('The transaction is not mined yet');
+  }
+
+  /**
+   * It returns a promise that resolves when the transaction is successfully mined and the status is 0x1, otherwise it rejects.
+   * In both cases it retrieves the transaction receipt
+   * @returns {Promise<TransactionReceipt>}
+   */
+  mined () {
+    return new Promise((resolve, reject) => {
+      this.on('transactionSuccess', (transactionReceipt) => {
+        resolve(transactionReceipt);
+      });
+      this.on('transactionFailed', (transactionReceipt) => {
+        reject(transactionReceipt);
+      });
+    });
+  }
+}

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -286,6 +286,14 @@ module.exports = class MetamaskController extends EventEmitter {
       this.isClientOpenAndUnlocked = memState.isUnlocked && this._isClientOpen
     })
 
+    // RIF
+    this.rifController = new RifController({
+      initState: initState.RifController,
+      preferencesController: this.preferencesController,
+      networkController: this.networkController,
+      transactionController: this.txController,
+    });
+
     this.store.updateStructure({
       TransactionController: this.txController.store,
       KeyringController: this.keyringController.store,
@@ -299,6 +307,7 @@ module.exports = class MetamaskController extends EventEmitter {
       CachedBalancesController: this.cachedBalancesController.store,
       // PermissionsController: this.permissionsController.permissions,
       // PermissionsMetadata: this.permissionsController.store,
+      RifController: this.rifController.store,
     })
 
     this.memStore = new ComposableObservableStore(null, {
@@ -323,17 +332,9 @@ module.exports = class MetamaskController extends EventEmitter {
       InfuraController: this.infuraController.store,
       // PermissionsController: this.permissionsController.permissions,
       // PermissionsMetadata: this.permissionsController.store,
+      RifController: this.rifController.store,
     })
     this.memStore.subscribe(this.sendUpdate.bind(this))
-
-    // RIF
-    this.rifController = new RifController({
-      preferencesController: this.preferencesController,
-      networkController: this.networkController,
-      transactionController: this.txController,
-      memoryStore: this.memStore,
-      metamaskStore: this.store,
-    });
 
   }
 

--- a/old-ui/app/components/error.js
+++ b/old-ui/app/components/error.js
@@ -51,7 +51,7 @@ class ErrorComponent extends Component {
 
 function mapStateToProps (state) {
   return {
-    error: state.appState.warning,
+    error: state.appState.warning ? state.appState.warning.message : null,
   }
 }
 

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -1287,7 +1287,11 @@ function updateAndApproveTx (txData, afterApproval) {
         dispatch(actions.clearSend())
         if (afterApproval) {
           dispatch(actions.hideLoadingIndication())
-          afterApproval.action(afterApproval.payload);
+          if (afterApproval.payload) {
+            afterApproval.action(afterApproval.payload);
+          } else {
+            afterApproval.action();
+          }
         } else {
           dispatch(actions.completedTx(txData.id))
           dispatch(actions.hideLoadingIndication())

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -658,7 +658,7 @@ function reduceApp (state, action) {
 
     case actions.HIDE_TOAST:
       return extend(appState, {
-        toastMsg: undefined,
+        toast: undefined,
       })
 
     case actions.DISPLAY_WARNING:

--- a/ui/app/rif/actions.js
+++ b/ui/app/rif/actions.js
@@ -257,15 +257,19 @@ function getSubdomains (domainName) {
   };
 }
 
-function createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddress) {
+function createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddress, successCallback) {
   return (dispatch) => {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve) => {
       dispatch(actions.hideLoadingIndication());
-      background.rif.rns.register.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress, (error) => {
+      background.rif.rns.register.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress, (error, transactionListener) => {
         if (error) {
           dispatch(actions.displayWarning(error));
         }
+        transactionListener.mined()
+          .then(transactionReceipt => {
+            successCallback(transactionReceipt);
+          });
       });
       return resolve();
     });

--- a/ui/app/rif/actions.js
+++ b/ui/app/rif/actions.js
@@ -23,6 +23,8 @@ const rifActions = {
   showModal,
   hideModal,
   getSubdomains,
+  createSubdomain,
+  isSubdomainAvailable,
 }
 
 let background = null;
@@ -249,6 +251,37 @@ function getSubdomains (domainName) {
           return reject(error);
         }
         return resolve(result);
+      });
+    });
+  };
+}
+
+function createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddress) {
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
+    return new Promise((resolve) => {
+      dispatch(actions.hideLoadingIndication());
+      background.rif.rns.register.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress, (error) => {
+        if (error) {
+          dispatch(actions.displayWarning(error));
+        }
+      });
+      return resolve();
+    });
+  };
+}
+
+function isSubdomainAvailable (domainName, subdomain) {
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
+    return new Promise((resolve) => {
+      dispatch(actions.hideLoadingIndication());
+      background.rif.rns.register.isSubdomainAvailable(domainName, subdomain, (error, available) => {
+        if (error) {
+          dispatch(actions.displayWarning(error));
+          return reject(error);
+        }
+        return resolve(available);
       });
     });
   };

--- a/ui/app/rif/actions.js
+++ b/ui/app/rif/actions.js
@@ -25,6 +25,7 @@ const rifActions = {
   getSubdomains,
   createSubdomain,
   isSubdomainAvailable,
+  goToConfirmPageForLastTransaction,
 }
 
 let background = null;
@@ -274,7 +275,7 @@ function createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddres
 function isSubdomainAvailable (domainName, subdomain) {
   return (dispatch) => {
     dispatch(actions.showLoadingIndication())
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       dispatch(actions.hideLoadingIndication());
       background.rif.rns.register.isSubdomainAvailable(domainName, subdomain, (error, available) => {
         if (error) {
@@ -285,6 +286,18 @@ function isSubdomainAvailable (domainName, subdomain) {
       });
     });
   };
+}
+
+function goToConfirmPageForLastTransaction (afterApproval) {
+  return (dispatch) => {
+    dispatch(getUnapprovedTransactions()).then(latestTransaction => {
+      dispatch(actions.showConfTxPage({
+        id: latestTransaction.id,
+        unapprovedTransactions: latestTransaction,
+        afterApproval,
+      }));
+    });
+  }
 }
 
 module.exports = rifActions

--- a/ui/app/rif/actions.js
+++ b/ui/app/rif/actions.js
@@ -1,5 +1,4 @@
 const actions = require('../actions');
-
 import extend from 'xtend'
 
 const rifActions = {
@@ -26,6 +25,7 @@ const rifActions = {
   createSubdomain,
   isSubdomainAvailable,
   goToConfirmPageForLastTransaction,
+  waitForTransactionListener,
 }
 
 let background = null;
@@ -73,13 +73,13 @@ function requestDomainRegistration (domainName, yearsToRegister) {
   return (dispatch) => {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve, reject) => {
-      background.rif.rns.register.requestRegistration(domainName, yearsToRegister, (error, commitment) => {
+      background.rif.rns.register.requestRegistration(domainName, yearsToRegister, (error, result) => {
         dispatch(actions.hideLoadingIndication());
         if (error) {
           dispatch(actions.displayWarning(error));
           return reject(error);
         }
-        return resolve(commitment);
+        return resolve(result);
       });
     });
   };
@@ -106,12 +106,12 @@ function finishRegistration (domainName) {
     dispatch(actions.showLoadingIndication())
     return new Promise((resolve) => {
       dispatch(actions.hideLoadingIndication());
-      background.rif.rns.register.finishRegistration(domainName, (error, result) => {
+      background.rif.rns.register.finishRegistration(domainName, (error, transactionListenerId) => {
         if (error) {
           dispatch(actions.displayWarning(error));
         }
+        return resolve(transactionListenerId);
       });
-      return resolve();
     });
   };
 }
@@ -257,21 +257,32 @@ function getSubdomains (domainName) {
   };
 }
 
-function createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddress, successCallback) {
+function waitForTransactionListener (transactionListenerId) {
   return (dispatch) => {
-    dispatch(actions.showLoadingIndication())
-    return new Promise((resolve) => {
-      dispatch(actions.hideLoadingIndication());
-      background.rif.rns.register.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress, (error, transactionListener) => {
+    return new Promise((resolve, reject) => {
+      background.rif.rns.register.waitForTransactionListener(transactionListenerId, (error, transactionReceipt) => {
         if (error) {
           dispatch(actions.displayWarning(error));
+          return reject(error);
         }
-        transactionListener.mined()
-          .then(transactionReceipt => {
-            successCallback(transactionReceipt);
-          });
+        return resolve(transactionReceipt);
       });
-      return resolve();
+    });
+  };
+}
+
+function createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddress) {
+  return (dispatch) => {
+    dispatch(actions.showLoadingIndication())
+    return new Promise((resolve, reject) => {
+      background.rif.rns.register.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress, (error, transactionListenerId) => {
+        dispatch(actions.hideLoadingIndication());
+        if (error) {
+          dispatch(actions.displayWarning(error));
+          return reject(error);
+        }
+        return resolve(transactionListenerId);
+      });
     });
   };
 }
@@ -294,12 +305,15 @@ function isSubdomainAvailable (domainName, subdomain) {
 
 function goToConfirmPageForLastTransaction (afterApproval) {
   return (dispatch) => {
-    dispatch(getUnapprovedTransactions()).then(latestTransaction => {
-      dispatch(actions.showConfTxPage({
-        id: latestTransaction.id,
-        unapprovedTransactions: latestTransaction,
-        afterApproval,
-      }));
+    dispatch(waitUntil(200)).then(() => {
+      dispatch(getUnapprovedTransactions())
+        .then(latestTransaction => {
+          dispatch(actions.showConfTxPage({
+            id: latestTransaction.id,
+            unapprovedTransactions: latestTransaction,
+            afterApproval,
+          }));
+      });
     });
   }
 }

--- a/ui/app/rif/components/modal/modal.css
+++ b/ui/app/rif/components/modal/modal.css
@@ -4,6 +4,7 @@
   justify-content: space-between;
   align-items: center;
   text-align: center;
+  width: 100%;
 }
 
 .modal-message>h1 {
@@ -34,4 +35,7 @@
   max-width: 90%;
   background: white;
   padding: 1em;
+}
+.modal-body {
+  width: 100%;
 }

--- a/ui/app/rif/components/modal/modal.js
+++ b/ui/app/rif/components/modal/modal.js
@@ -39,7 +39,23 @@ class CustomModal extends Component {
     this.closeModal();
   }
 
+  getButtons () {
+    let cancelButton = (<button onClick={this.cancel.bind(this)}>{this.props.message.cancelLabel}</button>);
+    let confirmButton = (<button onClick={this.confirm.bind(this)}>{this.props.message.confirmLabel}</button>);
+    if (this.props.message.hideCancel) {
+      cancelButton = null;
+    }
+    if (this.props.message.hideConfirm) {
+      confirmButton = null;
+    }
+    return {
+      cancelButton,
+      confirmButton,
+    }
+  }
+
   render () {
+    const buttons = this.getButtons();
     let body = null;
     if (this.props.message.body.text) {
       body = (<p>{this.props.message.body.text}</p>);
@@ -57,10 +73,12 @@ class CustomModal extends Component {
         className="modal">
         <div className="modal-message">
           <h1>{this.props.message.title}</h1>
-          {body}
+          <div className="modal-body">
+            {body}
+          </div>
           <div className="modal-buttons">
-            <button onClick={this.cancel.bind(this)}>{this.props.message.cancelLabel}</button>
-            <button onClick={this.confirm.bind(this)}>{this.props.message.confirmLabel}</button>
+            {buttons.cancelButton}
+            {buttons.confirmButton}
           </div>
         </div>
       </Modal>

--- a/ui/app/rif/components/modal/modal.js
+++ b/ui/app/rif/components/modal/modal.js
@@ -20,13 +20,22 @@ class CustomModal extends Component {
     this.props.dispatch(rifActions.hideModal());
   }
 
-  cancel () {
-    this.props.message.cancelCallback();
+  async cancel () {
+    if (this.props.message.cancelCallback) {
+      this.props.message.cancelCallback();
+    }
     this.closeModal();
   }
 
-  confirm () {
-    this.props.message.confirmCallback();
+  async confirm () {
+    if (this.props.message.validateConfirm) {
+      if (!await this.props.message.validateConfirm()) {
+        return;
+      }
+    }
+    if (this.props.message.confirmCallback) {
+      this.props.message.confirmCallback();
+    }
     this.closeModal();
   }
 

--- a/ui/app/rif/components/searchDomains.js
+++ b/ui/app/rif/components/searchDomains.js
@@ -16,7 +16,7 @@ class SearchDomains extends Component {
 
   _handleKeyDown = (e) => {
     if (e.key === 'Enter') {
-      const typedDomain = e.target.value.toLowerCase();
+      const typedDomain = (e.target.value.toLowerCase() && e.target.value.toLowerCase().indexOf('.rsk') === -1) ? (e.target.value.toLowerCase() + '.rsk') : e.target.value.toLowerCase();
       // There is a limitation in manager that domains with less 5 characters are blocked
       if (typedDomain.length <= 5) {
         this.props.displayWarning('Domains with less than 5 characters are blocked.');
@@ -30,7 +30,7 @@ class SearchDomains extends Component {
       } else {
         // Checks if the domain is available, so if it is, it need to render a screen so the user can register it
         this.props.checkDomainAvailable(typedDomain).then(domain => {
-          if (domain.length > 0) {
+          if (domain) {
             this.props.showDomainRegisterPage(typedDomain);
           } else {
             // We need to put an else here, so we can redirect to details page, remember that the localstorage part of code, will not be anymore here

--- a/ui/app/rif/components/searchDomains.js
+++ b/ui/app/rif/components/searchDomains.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux'
 import rifActions from '../../rif/actions'
 import actions from '../../actions'
 import {pageNames} from '../pages'
+import {cleanDomainName} from '../utils/parse'
 
 class SearchDomains extends Component {
 
@@ -16,7 +17,7 @@ class SearchDomains extends Component {
 
   _handleKeyDown = (e) => {
     if (e.key === 'Enter') {
-      const typedDomain = (e.target.value.toLowerCase() && e.target.value.toLowerCase().indexOf('.rsk') === -1) ? (e.target.value.toLowerCase() + '.rsk') : e.target.value.toLowerCase();
+      const typedDomain = cleanDomainName(e.target.value);
       // There is a limitation in manager that domains with less 5 characters are blocked
       if (typedDomain.length <= 5) {
         this.props.displayWarning('Domains with less than 5 characters are blocked.');

--- a/ui/app/rif/pages/common-style-pages.css
+++ b/ui/app/rif/pages/common-style-pages.css
@@ -15,3 +15,10 @@
 .hand-over {
   cursor: pointer;
 }
+.body {
+  width: 100%;
+  overflow: scroll;
+  height: 26.5em;
+  overflow-x: hidden;
+  font-family: Nunito Regular;
+}

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
@@ -111,13 +111,13 @@ class DomainsDetailActiveScreen extends Component {
       isRifStorage,
       content,
     };
-		let networks = this.state.resolvers[this.state.selectedResolverIndex].network.map((network, index) => {
+		const networks = this.state.resolvers && this.state.resolvers[this.state.selectedResolverIndex] ? this.state.resolvers[this.state.selectedResolverIndex].network.map((network, index) => {
 			return <div key={index} className={'resolver-network-description'}>
 					<FontAwesomeIcon icon={getIconForToken(network.networkIcon).icon} color={getIconForToken(network.networkIcon).color} className={'domain-icon'}/>
 					<span>{network.networkName}</span>
 					<span className={'resolver-network-description-address'}>{network.address}</span>
 				</div>
-			})
+			}) : [];
 		return (
 		<div className={'body'}>
             <DomainHeader domainName={domainName}

--- a/ui/app/rif/pages/domainsPage/domain-page.css
+++ b/ui/app/rif/pages/domainsPage/domain-page.css
@@ -1,9 +1,3 @@
-.body {
-    width: 100%; 
-    height: 600px;
-    overflow: scroll;
-    font-family: Nunito Regular;
-}
 .chiplet {
     width: 90%;
     height: 100px;
@@ -37,7 +31,7 @@
 }
 .chiplet-status-wrapper {
     width: 15%;
-    height: 100%; 
+    height: 100%;
     float: right;
     position: relative;
 }

--- a/ui/app/rif/pages/rns/register/index.css
+++ b/ui/app/rif/pages/rns/register/index.css
@@ -132,10 +132,10 @@
 .domainRegisterProgress>div>article {
   border-radius: 50%;
   background-size: 88%;
-  height: 10em;
+  height: 7em;
   padding-bottom: 31%;
   position: relative;
-  width: 10em;
+  width: 7em;
   border: solid 0.2em #00a344;
   margin: 2em;
 }

--- a/ui/app/rif/pages/rns/subdomains/index.css
+++ b/ui/app/rif/pages/rns/subdomains/index.css
@@ -1,6 +1,7 @@
 .subdomains .list {
   display: flex;
-  justify-content: center;
+  justify-content: left;
+  padding: 2em;
 }
 .subdomains .new-button {
   border-radius: 0.2em;
@@ -24,4 +25,13 @@
   display: flex;
   justify-content: flex-end;
   margin: 1em;
+}
+.subdomains .list>ul {
+  width: 100%;
+}
+.subdomains .list>ul>li {
+  font-weight: bold;
+  font-size: 1.3em;
+  border-bottom: solid 0.1em #bbbbbb;
+  padding-bottom: 0.5em;
 }

--- a/ui/app/rif/pages/rns/subdomains/index.css
+++ b/ui/app/rif/pages/rns/subdomains/index.css
@@ -34,4 +34,5 @@
   font-size: 1.3em;
   border-bottom: solid 0.1em #bbbbbb;
   padding-bottom: 0.5em;
+  margin-top: 1em;
 }

--- a/ui/app/rif/pages/rns/subdomains/index.css
+++ b/ui/app/rif/pages/rns/subdomains/index.css
@@ -36,3 +36,11 @@
   padding-bottom: 0.5em;
   margin-top: 1em;
 }
+.subdomain-popup-view>div>label {
+  font-weight: bold;
+  margin-right: 1em;
+}
+.subdomain-address {
+  overflow-wrap: break-word;
+  margin-right: 1em;
+}

--- a/ui/app/rif/pages/rns/subdomains/index.js
+++ b/ui/app/rif/pages/rns/subdomains/index.js
@@ -94,14 +94,23 @@ class Subdomains extends Component {
       elements: inputs,
       confirmLabel: 'Next',
       confirmCallback: async () => {
-        await this.props.createSubdomain(this.props.domainInfo.domainName, this.state.newSubdomain.name, this.state.newSubdomain.owner, this.props.domainInfo.ownerAddress);
+        await this.props.createSubdomain(
+          this.props.domainInfo.domainName,
+          this.state.newSubdomain.name,
+          this.state.newSubdomain.owner,
+          this.props.domainInfo.ownerAddress,
+          (transactionReceipt) => {
+            this.loadSubdomains();
+          });
         this.props.showPopup('Confirmation', {
           text: 'Please confirm the operation in the next screen to create the subdomain.',
           hideCancel: true,
           confirmCallback: async () => {
             this.props.showTransactionConfirmPage({
               action: (payload) => {
-                this.loadSubdomains();
+                this.props.showThis({
+                  ...this.props,
+                });
               },
               payload: null,
             });
@@ -193,7 +202,8 @@ function mapDispatchToProps (dispatch) {
         hideCancel: opts.hideCancel,
       }));
     },
-    createSubdomain: (domainName, subdomain, ownerAddress, parentOwnerAddress) => dispatch(rifActions.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress)),
+    createSubdomain: (domainName, subdomain, ownerAddress, parentOwnerAddress, successCallback) =>
+      dispatch(rifActions.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress, successCallback)),
     showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
     showTransactionConfirmPage: (afterApproval) => dispatch(rifActions.goToConfirmPageForLastTransaction(afterApproval)),
     isSubdomainAvailable: (domainName, subdomain) => dispatch(rifActions.isSubdomainAvailable(domainName, subdomain)),

--- a/ui/app/rif/utils/parse.js
+++ b/ui/app/rif/utils/parse.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the domain name cleared ready to use, with the .rsk suffix and to lowercase.
+ * @param domainName the domain name to clear.
+ * @returns the cleared domain name
+ */
+export function cleanDomainName (domainName) {
+  const toLowerCaseDomainName = domainName ? domainName.toLowerCase() : domainName;
+  const withRskSuffix = (toLowerCaseDomainName && toLowerCaseDomainName.indexOf('.rsk') === -1) ? (toLowerCaseDomainName + '.rsk') : toLowerCaseDomainName;
+  return withRskSuffix;
+}


### PR DESCRIPTION
This PR introduces the popup for view details on a subdomain. Basically we can view the name and address of the subdomain and copy the address to the clipboard if we want. Here is a demo:

![demo-06-05-2020-jonathan-view-subdomain](https://user-images.githubusercontent.com/7540348/81233768-c7b7ca80-8fcd-11ea-9c5e-0f00d0ee6060.gif)

We fixed the stores on rif to have storage on our pages.

**Important note: we add transaction listener with transaction receipt control to manage when a transaction is pending.**

This only affects the ui.
