### PR TITLE
RIFEX-102 Close Channel 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,7 @@ notes.txt
 .nyc_output
 
 /old-ui/app/css/rif.css
-./rif.config.js
-./rif
+rif.config.js
+rif/rif.config.local.js
+rif/rif.config.staging.js
+rif/rif.config.production.js

--- a/app/scripts/controllers/rif/lumino/index.js
+++ b/app/scripts/controllers/rif/lumino/index.js
@@ -101,6 +101,8 @@ export class LuminoManager extends AbstractManager {
       onboarding: bindOperation(this.operations.onboarding, this.operations),
       openChannel: bindOperation(this.operations.openChannel, this.operations),
       closeChannel: bindOperation(this.operations.closeChannel, this.operations),
+      subscribeToCloseChannel: bindOperation(this.operations.subscribeToCloseChannel, this.operations),
+      deleteChannelFromSDK: bindOperation(this.operations.deleteChannelFromSdk, this.operations),
       createDeposit: bindOperation(this.operations.createDeposit, this.operations),
       createPayment: bindOperation(this.operations.createPayment, this.operations),
       getChannels: bindOperation(this.operations.getChannels, this.operations),

--- a/ui/app/rif/components/lumino/close-channel/index.js
+++ b/ui/app/rif/components/lumino/close-channel/index.js
@@ -1,0 +1,82 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
+import rifActions from '../../../actions';
+import {CallbackHandlers} from '../../../actions/callback-handlers';
+import niftyActions from '../../../../actions';
+
+class CloseChannel extends Component {
+
+  static propTypes = {
+    buttonLabel: PropTypes.string,
+    partner: PropTypes.string.isRequired,
+    tokenAddress: PropTypes.string.isRequired,
+    tokenNetworkAddress: PropTypes.string.isRequired,
+    tokenName: PropTypes.string.isRequired,
+    channelIdentifier: PropTypes.string.isRequired,
+    showToast: PropTypes.func,
+    showPopup: PropTypes.func,
+    closeChannel: PropTypes.func,
+    deleteChannelFromSdk: PropTypes.func,
+    afterCloseChannel: PropTypes.func,
+    subscribeToCloseChannel: PropTypes.func,
+  }
+
+  closeChannelModal () {
+    this.props.showPopup('Close Channel', {
+      text: `Are you sure you want to close channel ${this.props.channelIdentifier} with partner ${this.props.partner} for token ${this.props.tokenName}?`,
+      confirmCallback: async () => {
+        const callbackHandlers = new CallbackHandlers();
+        callbackHandlers.requestHandler = async (result) => {
+          console.debug('CLOSE CHANNEL REQUESTED', result);
+          this.props.showToast('Requesting Close Channel');
+          await this.props.subscribeToCloseChannel(this.props.channelIdentifier, this.props.tokenAddress);
+        };
+        callbackHandlers.successHandler = async (result) => {
+          console.debug('CLOSE CHANNEL DONE', result);
+          await this.props.deleteChannelFromSdk(this.props.channelIdentifier, this.props.tokenAddress);
+          if (this.props.afterCloseChannel) {
+            this.props.afterCloseChannel(result);
+          }
+          this.props.showToast('Channel Closed Successfully!');
+        };
+        callbackHandlers.errorHandler = (result) => {
+          console.debug('CLOSE CHANNEL ERROR', result);
+          const errorMessage = result.response.data.errors;
+          if (errorMessage) {
+            this.props.showToast(errorMessage, false);
+          } else {
+            this.props.showToast('Unknown Error trying to close channel!', false);
+          }
+        };
+        await this.props.closeChannel(this.props.partner, this.props.tokenAddress, this.props.tokenNetworkAddress, this.props.channelIdentifier, callbackHandlers);
+      },
+    });
+  }
+
+  render () {
+    return (
+      <div>
+        <button className="btn-primary btn-primary-outlined" onClick={() => this.closeChannelModal()}>{this.props.buttonLabel ? this.props.buttonLabel : 'Close'}</button>
+      </div>
+    );
+  }
+}
+
+function mapDispatchToProps (dispatch) {
+  return {
+    closeChannel: (partner, tokenAddress, tokenNetworkAddress, channelIdentifier, callbackHandlers) =>
+      dispatch(rifActions.closeChannel(partner, tokenAddress, tokenNetworkAddress, channelIdentifier, callbackHandlers)),
+    deleteChannelFromSdk: (channelIdentifier, tokenAddress) => dispatch(rifActions.deleteChannelFromSdk(channelIdentifier, tokenAddress)),
+    showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
+    showPopup: (title, opts) => {
+      dispatch(rifActions.showModal({
+        title,
+        ...opts,
+      }));
+    },
+    subscribeToCloseChannel: (channelIdentifier, tokenAddress) => dispatch(rifActions.subscribeToCloseChannel(channelIdentifier, tokenAddress)),
+  };
+}
+
+module.exports = connect(null, mapDispatchToProps)(CloseChannel)

--- a/ui/app/rif/pages/rns/pay/index.js
+++ b/ui/app/rif/pages/rns/pay/index.js
@@ -13,7 +13,6 @@ import ethUtils from 'ethereumjs-util';
 import {isValidRNSDomain} from '../../../utils/parse';
 import web3Utils from 'web3-utils';
 import {validateDecimalAmount} from '../../../utils/validations';
-import OpenChannel from '../../../components/lumino/open-channel';
 
 class ModeOption extends Select.Option {
   render () {

--- a/ui/app/rif/utils/parse.js
+++ b/ui/app/rif/utils/parse.js
@@ -15,7 +15,12 @@ function isValidRNSDomain (value) {
   return !!value.match('.*\\.rsk');
 }
 
+function parseLuminoError (error) {
+  return error && error.response && error.response.data && error.response.data.errors && error.response.data.errors ? error.response.data.errors : null;
+}
+
 export {
+  parseLuminoError,
   cleanDomainName,
   isValidRNSDomain,
 }


### PR DESCRIPTION
This PR introduces the Close Channel component, this can be used like this:

`<CloseChannel partner={}
                              buttonLabel={}
                              tokenAddress={}
                              tokenNetworkAddress={}
                              tokenName={}
                              channelIdentifier={}/>`

The component just shows a button that when you click on it shows a confirmation to close the channel, here a screenshot:

![imagen](https://user-images.githubusercontent.com/7540348/84545073-f4e64f80-acd4-11ea-949d-7dc50a0afce1.png)

This affects UI and Service Layers