### PR TITLE
RIFEX-104 Fixing Confirm Page Bugs for RSK

### DIFF
--- a/app/scripts/controllers/network/enums.js
+++ b/app/scripts/controllers/network/enums.js
@@ -9,6 +9,7 @@ const GOERLI_TESTNET = 'goerli_testnet'
 const CLASSIC = 'classic'
 const RSK = 'rsk'
 const RSK_TESTNET = 'rsk_testnet'
+const RSK_REGTEST = 'rsk_regtest'
 const LOCALHOST = 'localhost'
 
 const ETH_TICK = 'ETH'
@@ -26,6 +27,7 @@ const DAI_CHAINID = '0x64'
 const POA_SOKOL_CHAINID = '0x4D'
 const RSK_CHAINID = '0x1E'
 const RSK_TESTNET_CHAINID = '0x1F'
+const RSK_REGTEST_CHAINID = '0x21'
 const CLASSIC_CHAINID = '0x3D'
 
 const POA_CODE = 99
@@ -39,6 +41,7 @@ const GOERLI_TESTNET_CODE = 5
 const CLASSIC_CODE = 61
 const RSK_CODE = 30
 const RSK_TESTNET_CODE = 31
+const RSK_REGTEST_CODE = 33;
 
 const POA_DISPLAY_NAME = 'POA'
 const DAI_DISPLAY_NAME = 'xDai'
@@ -94,6 +97,7 @@ module.exports = {
   POA_SOKOL_CHAINID,
   RSK_CHAINID,
   RSK_TESTNET_CHAINID,
+  RSK_REGTEST_CHAINID,
   DAI,
   POA_SOKOL,
   MAINNET,
@@ -104,6 +108,7 @@ module.exports = {
   CLASSIC,
   RSK,
   RSK_TESTNET,
+  RSK_REGTEST,
   LOCALHOST,
   POA_CODE,
   DAI_CODE,
@@ -117,6 +122,7 @@ module.exports = {
   CLASSIC_CHAINID,
   RSK_CODE,
   RSK_TESTNET_CODE,
+  RSK_REGTEST_CODE,
   POA_DISPLAY_NAME,
   DAI_DISPLAY_NAME,
   POA_SOKOL_DISPLAY_NAME,

--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -30,6 +30,8 @@ const {
   RSK_CODE,
   RSK_CHAINID,
   RSK_TESTNET_CODE,
+  RSK_REGTEST_CODE,
+  RSK_REGTEST_CHAINID,
   RSK_TESTNET_CHAINID,
   LOCALHOST,
   CLASSIC,
@@ -38,6 +40,7 @@ const {
   CLASSIC_TICK,
   RSK,
   RSK_TESTNET,
+  RSK_REGTEST,
   RSK_TICK,
   customDPaths,
 } = require('../../app/scripts/controllers/network/enums')
@@ -428,12 +431,12 @@ function getAllKeyRingsAccounts (keyrings, network) {
 function ifRSK (network) {
   if (!network) return false
   const numericNet = isNaN(network) ? network : parseInt(network)
-  return numericNet === RSK_CODE || numericNet === RSK_TESTNET_CODE
+  return numericNet === RSK_CODE || numericNet === RSK_TESTNET_CODE || numericNet === RSK_REGTEST_CODE
 }
 
 function ifRSKByProviderType (type) {
   if (!type) return false
-  return type === RSK || type === RSK_TESTNET
+  return type === RSK || type === RSK_TESTNET || type === RSK_REGTEST
 }
 
 function ifPOA (network) {
@@ -485,7 +488,8 @@ function isKnownProvider (type) {
   type === GOERLI_TESTNET ||
   type === CLASSIC ||
   type === RSK ||
-  type === RSK_TESTNET
+  type === RSK_TESTNET ||
+  type === RSK_REGTEST
 }
 
 function getNetworkID ({ network }) {
@@ -541,6 +545,11 @@ function getNetworkID ({ network }) {
     case RSK_TESTNET:
       netId = RSK_TESTNET_CODE.toString()
       chainId = RSK_TESTNET_CHAINID
+      ticker = RSK_TICK
+      break
+    case RSK_REGTEST:
+      netId = RSK_REGTEST_CODE.toString()
+      chainId = RSK_REGTEST_CHAINID
       ticker = RSK_TICK
       break
     case CLASSIC:

--- a/ui/app/rif/pages/index.js
+++ b/ui/app/rif/pages/index.js
@@ -21,6 +21,7 @@ import ErrorComponent from '../../../../old-ui/app/components/error';
 import LuminoHome from './lumino/index';
 import {pageNames} from './names';
 import RifConfiguration from './configuration';
+import niftyActions from '../../actions';
 
 function getSearchBarComponent (show) {
   if (!show) {
@@ -75,6 +76,14 @@ function buildTabScreen (screenName, context, dispatch) {
               <RifConfiguration />
             </div>);
   }
+  // check if rif it's available
+  dispatch(rifActions.rifEnabled())
+    .then(enabled => {
+      if (!enabled) {
+        // if not available we redirect to home
+        dispatch(niftyActions.goHome());
+      }
+    });
   const tabOptions = context.params.tabOptions;
   const tabs = buildTabs(screenName, tabOptions, dispatch);
   const onTabChange = (tab) => {


### PR DESCRIPTION

![imagen](https://user-images.githubusercontent.com/7540348/84957112-ecc15200-b0d0-11ea-8bb4-62f162aece59.png)


* Fixing changing network when we are in a rif page, now it goes back to home if we change to a not RSK network.
* Adding regtest as a known network for rsk to get the total amounts working properly on the confirm page.

This affects the ui and nifty service layer.