### PR TITLE
Mocks for RIFEX-106 and table component usage

### DIFF
--- a/app/scripts/controllers/rif/abstract-manager.js
+++ b/app/scripts/controllers/rif/abstract-manager.js
@@ -1,5 +1,6 @@
 import extend from 'xtend';
 import ObservableStore from 'obs-store';
+import {global} from './constants';
 
 /**
  * Abstract manager to encapsulate the logic to catch preferences updates and other stuff shared by managers.
@@ -49,4 +50,25 @@ export class AbstractManager {
    * @returns an object like { operationName: function bind}
    */
   bindApi () {}
+
+  /**
+   * Updates the store state
+   * @param newState
+   */
+  updateStoreState (newState) {
+    const storeState = this.store.getState();
+    const currentNetworkId = this.networkController.getNetworkState() === 'loading' ? global.networks.main : this.networkController.getNetworkState();
+    storeState[currentNetworkId] = newState;
+    this.store.putState(storeState);
+  }
+
+  /**
+   * Gets the store state
+   * @returns the current state
+   */
+  getStoreState () {
+    const storeState = this.store.getState();
+    const currentNetworkId = this.networkController.getNetworkState() === 'loading' ? global.networks.main : this.networkController.getNetworkState();
+    return storeState[currentNetworkId] ? storeState[currentNetworkId] : {};
+  }
 }

--- a/app/scripts/controllers/rif/index.js
+++ b/app/scripts/controllers/rif/index.js
@@ -4,6 +4,7 @@ import ComposableObservableStore from './../../lib/ComposableObservableStore'
 import {LuminoManager} from './lumino';
 import {bindOperation, isRskNetwork} from './utils/general';
 import {RifConfigurationProvider} from './configuration';
+import {global} from './constants';
 
 /**
  * RIF Controller
@@ -27,10 +28,15 @@ export default class RifController {
 
     const initState = props.initState || {};
 
+    const currentNetworkId = this.metamaskController.networkController.getNetworkState() === 'loading' ? global.networks.main :
+      this.metamaskController.networkController.getNetworkState();
+
     this.configurationProvider = new RifConfigurationProvider({
       initState: initState.RifConfigurationProvider,
       networkController: this.metamaskController.networkController,
     });
+
+    this.configurationProvider.loadConfiguration(currentNetworkId);
 
     this.rnsManager = new RnsManager({
       initState: initState.RnsManager,
@@ -164,9 +170,11 @@ export default class RifController {
   }
 
   setConfiguration (configuration) {
-    this.configurationProvider.setConfiguration(configuration);
-    this.rnsManager.onConfigurationUpdated(configuration);
-    this.luminoManager.onConfigurationUpdated(configuration);
+    if (configuration) {
+      this.configurationProvider.setConfiguration(configuration);
+      this.rnsManager.onConfigurationUpdated(configuration);
+      this.luminoManager.onConfigurationUpdated(configuration);
+    }
     return Promise.resolve();
   }
 

--- a/app/scripts/controllers/rif/lumino/index.js
+++ b/app/scripts/controllers/rif/lumino/index.js
@@ -62,13 +62,13 @@ export class LuminoManager extends AbstractManager {
         },
       }
       await this.lumino.init(signingHandler, storageHandler, configParams);
-      const state = this.store.getState();
+      const state = this.getStoreState();
         if (state.apiKey && !cleanApiKey) {
           await this.operations.setApiKey(state.apiKey);
         } else {
           await this.operations.onboarding();
           state.apiKey = await this.operations.getApiKey();
-          this.store.putState(state);
+          this.updateStoreState(state);
         }
       await this.afterInitialization();
     }

--- a/app/scripts/controllers/rif/rns/index.js
+++ b/app/scripts/controllers/rif/rns/index.js
@@ -4,9 +4,9 @@ import RnsTransfer from './transfer'
 import RNS from './abis/RNS.json'
 import RIF from './abis/RIF.json'
 import extend from 'xtend'
-import ObservableStore from 'obs-store'
 import {RnsContainer} from './container';
 import {AbstractManager} from '../abstract-manager';
+import {isRskNetwork} from '../utils/general';
 
 /**
  * This class encapsulates all the RNS operations, it initializes and call to all the delegates and exposes their operations.
@@ -17,16 +17,15 @@ import {AbstractManager} from '../abstract-manager';
  */
 export default class RnsManager extends AbstractManager {
   constructor (props) {
-    super(props);
-    const configuration = this.configurationProvider.getConfigurationObject();
-    this.rnsContractInstance = this.web3.eth.contract(RNS).at(configuration.rns.contracts.rns);
-    this.rifContractInstance = this.web3.eth.contract(RIF).at(configuration.rns.contracts.rif);
     const initState = extend({
       register: {},
       resolver: {},
       transfer: {},
     }, props.initState);
-    this.store = new ObservableStore(initState);
+    super(props, initState);
+    const configuration = this.configurationProvider.getConfigurationObject();
+    this.rnsContractInstance = this.web3.eth.contract(RNS).at(configuration.rns.contracts.rns);
+    this.rifContractInstance = this.web3.eth.contract(RIF).at(configuration.rns.contracts.rif);
 
     const register = new RnsRegister({
       web3: this.web3,
@@ -80,8 +79,10 @@ export default class RnsManager extends AbstractManager {
   }
 
   onNetworkChanged (network) {
-    const configuration = this.configurationProvider.getConfigurationObject();
-    this.reloadConfiguration(configuration);
+    if (isRskNetwork(network.id)) {
+      const configuration = this.configurationProvider.getConfigurationObject();
+      this.reloadConfiguration(configuration);
+    }
   }
 
   onConfigurationUpdated (configuration) {

--- a/app/scripts/controllers/rif/rns/register/index.js
+++ b/app/scripts/controllers/rif/rns/register/index.js
@@ -21,6 +21,7 @@ export default class RnsRegister extends RnsJsDelegate {
   }
 
   onConfigurationUpdated (configuration) {
+    super.onConfigurationUpdated(configuration);
     this.fifsAddrRegistrarAddress = configuration.rns.contracts.fifsAddrRegistrar;
     this.fifsAddrRegistrarInstance = this.web3.eth.contract(FIFSRegistrar).at(this.fifsAddrRegistrarAddress);
   }

--- a/app/scripts/controllers/rif/rns/resolver/index.js
+++ b/app/scripts/controllers/rif/rns/resolver/index.js
@@ -20,6 +20,7 @@ export default class RnsResolver extends RnsJsDelegate {
   }
 
   onConfigurationUpdated (configuration) {
+    super.onConfigurationUpdated(configuration);
     this.rskOwnerContractInstance = this.web3.eth.contract(RSKOwner).at(configuration.rns.contracts.rskOwner);
     this.multiChainresolverContractInstance = this.web3.eth.contract(MultiChainresolver).at(configuration.rns.contracts.multiChainResolver);
   }

--- a/app/scripts/controllers/rif/rns/rns-delegate.js
+++ b/app/scripts/controllers/rif/rns/rns-delegate.js
@@ -1,6 +1,7 @@
 import {TransactionListener} from '../transaction-listener';
 import extend from 'xtend';
 import {bindOperation} from '../utils/general';
+import {global} from '../constants';
 
 /**
  * Delegate class to encapsulate all the logic related to delegates.
@@ -195,7 +196,10 @@ export default class RnsDelegate {
    * @param newState
    */
   updateStoreState (newState) {
-    this.store.putState(newState);
+    const storeState = this.store.getState();
+    const currentNetworkId = this.networkController.getNetworkState() === 'loading' ? global.networks.main : this.networkController.getNetworkState();
+    storeState[currentNetworkId] = newState;
+    this.store.putState(storeState);
   }
 
   /**
@@ -203,7 +207,9 @@ export default class RnsDelegate {
    * @returns the current state
    */
   getStoreState () {
-    return this.store.getState();
+    const storeState = this.store.getState();
+    const currentNetworkId = this.networkController.getNetworkState() === 'loading' ? global.networks.main : this.networkController.getNetworkState();
+    return storeState[currentNetworkId] ? storeState[currentNetworkId] : {};
   }
 
   /**

--- a/app/scripts/controllers/rif/rns/rnsjs-delegate.js
+++ b/app/scripts/controllers/rif/rns/rnsjs-delegate.js
@@ -372,5 +372,9 @@ export default class RnsJsDelegate extends RnsDelegate {
     this.updateStateForContainer(rns.storeContainers.register, state);
   }
 
+  onConfigurationUpdated (configuration) {
+    super.onConfigurationUpdated(configuration);
+    this.rnsJs = new RNS(this.web3, this.getRNSOptions());
+  }
 
 }

--- a/app/scripts/controllers/rif/rns/transfer/index.js
+++ b/app/scripts/controllers/rif/rns/transfer/index.js
@@ -3,6 +3,10 @@ import RnsDelegate from '../rns-delegate';
 /**
  * This is a delegate to manage all the RNS transfer operations.
  */
-export default class RnsTransfer extends RnsDelegate {}
+export default class RnsTransfer extends RnsDelegate {
+  onConfigurationUpdated (configuration) {
+    super.onConfigurationUpdated(configuration);
+  }
+}
 
 

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -821,6 +821,7 @@ function getLuminoNetworks (userAddress) {
   return (dispatch) => {
 
     return new Promise((resolve, reject) => {
+      // TODO: Remove these mocks
       const networkMock1 = {
         symbol: 'MRIF',
         networkTokenAddress: '0x1234',
@@ -886,6 +887,7 @@ function getLuminoNetworks (userAddress) {
 
 function getUserChannelsInNetwork (tokenAddress) {
   return (dispatch) => new Promise((resolve, reject) => {
+      // TODO: Remove these mocks
       if (tokenAddress !== '0x12234') {
         return resolve([]);
       }

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -825,18 +825,18 @@ function getLuminoNetworks (userAddress) {
       // TODO: Remove these mocks
       const networkMock1 = {
         symbol: 'MRIF',
-        networkTokenAddress: '0x1234',
+        tokenAddress: '0x1234',
         name: 'Mock RIF',
-        networkAddress: '0x12345',
+        tokenNetwork: '0x12345',
         channels: 20,
         nodes: 5,
         userChannels: 0,
       }
       const networkMock2 = {
         symbol: 'MDoC',
-        networkTokenAddress: '0x12234',
+        tokenAddress: '0x12234',
         name: 'Mock DoC',
-        networkAddress: '0x122345',
+        tokenNetwork: '0x122345',
         channels: 20,
         nodes: 5,
         userChannels: 2,
@@ -854,9 +854,9 @@ function getLuminoNetworks (userAddress) {
         tokens.forEach(t => {
           const network = {
             symbol: t.symbol,
-            networkTokenAddress: t.address,
+            tokenAddress: t.address,
             name: t.name,
-            networkAddress: t.network_address,
+            tokenNetwork: t.network_address,
             channels: t.channels.length,
             nodes: 0,
             userChannels: 0,
@@ -891,9 +891,9 @@ function getLuminoNetworkData (tokenAddress) {
     return new Promise((resolve, reject) => {
       const emptyNetwork = {
         symbol: '???',
-        networkTokenAddress: '0x',
+        tokenAddress: '0x',
         name: '???',
-        networkAddress: '0x',
+        tokenNetwork: '0x',
         channels: 0,
         nodes: 0,
         userChannels: 0,
@@ -909,9 +909,9 @@ function getLuminoNetworkData (tokenAddress) {
           })
           const network = {
             symbol: data.symbol,
-            networkTokenAddress: data.address,
+            tokenAddress: data.address,
             name: data.name,
-            networkAddress: data.network_address,
+            tokenNetwork: data.network_address,
             channels: data.channels.length,
             nodes: Object.keys(nodesMap).length,
           }
@@ -952,8 +952,11 @@ function getUserChannelsInNetwork (tokenAddress) {
         dispatch(niftyActions.displayWarning(error));
         return reject(error);
       }
+      debugger;
+
       if (channels) {
         // We get only the values, since these are the ones we care about
+        debugger;
         const channelsArr = Object.values(channels).filter(ch => ch.token_address.toLowerCase() === tokenAddress);
         return resolve(channelsArr);
       }

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -819,7 +819,31 @@ function getTokensWithJoinedCheck () {
 
 function getLuminoNetworks (userAddress) {
   return (dispatch) => {
+
     return new Promise((resolve, reject) => {
+      const networkMock1 = {
+        symbol: 'MRIF',
+        networkTokenAddress: '0x1234',
+        name: 'Mock RIF',
+        networkAddress: '0x12345',
+        channels: 20,
+        nodes: 5,
+        userChannels: 0,
+      }
+      const networkMock2 = {
+        symbol: 'MDoC',
+        networkTokenAddress: '0x12234',
+        name: 'Mock DoC',
+        networkAddress: '0x122345',
+        channels: 20,
+        nodes: 5,
+        userChannels: 2,
+      }
+      const networksMock = {
+        withChannels: [networkMock2],
+        withoutChannels: [networkMock1],
+      }
+      resolve(networksMock);
       dispatch(this.getTokens()).then(tokens => {
         const networks = {
           withChannels: [],
@@ -862,6 +886,25 @@ function getLuminoNetworks (userAddress) {
 
 function getUserChannelsInNetwork (tokenAddress) {
   return (dispatch) => new Promise((resolve, reject) => {
+      if (tokenAddress !== '0x12234') {
+        return resolve([]);
+      }
+      const mockData = [
+        {
+          balance: '100000000000',
+          partner_address: '0x460218fcd497991b380f38b77c61334ad442e7f6',
+          channel_identifier: 1,
+          state: 'Open',
+        },
+        {
+          balance: '1000000000000000000000000',
+          channel_identifier: 2,
+          state: 'Open',
+          token_network_identifier: '0x41a34C1B6035E89FAdecb445dbAFe5804BC13a8E',
+          partner_address: '0xd7387C9b5a2860bFb6e8E8F36c8983B0469C6d18',
+        },
+      ]
+      return resolve(mockData);
       background.rif.lumino.getChannels((error, channels) => {
         if (error) {
           dispatch(niftyActions.displayWarning(error));

--- a/ui/app/rif/pages/lumino/index.js
+++ b/ui/app/rif/pages/lumino/index.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux'
 import rifActions from '../../actions';
 import LuminoNetworkItem from '../../components/LuminoNetworkItem';
 import {pageNames} from '../names';
+import {GenericTable} from '../../components';
 
 class LuminoHome extends Component {
 
@@ -35,22 +36,37 @@ class LuminoHome extends Component {
     return navigateTo(symbol, networkAddress, name, networkTokenAddress)
   }
 
+  getNetworkItems = networkArr => {
+    return networkArr.map(n => {
+      return {
+        content: <LuminoNetworkItem key={n.symbol} userChannels={n.userChannels}
+                                    symbol={n.symbol} nodes={n.nodes}
+                                    channels={n.channels}
+                                    onRightChevronClick={() => this.navigateToNetworkDetail(n)}/>,
+      }
+    });
+  }
+
   render () {
     const {networks} = this.state;
-    // TODO: Replace .map with instances of the <GenericTable /> from other branches
+    const myNetworks = this.getNetworkItems(networks.withChannels)
+    const otherNetworks = this.getNetworkItems(networks.withoutChannels)
+    const columns = [{
+      Header: 'Content',
+      accessor: 'content',
+    }];
     return (
       <div className="body">
-        <div>My Lumino networks available</div>
-        {networks.withChannels.map(n => <LuminoNetworkItem key={n.symbol} userChannels={n.userChannels}
-                                                           symbol={n.symbol} nodes={n.nodes}
-                                                           channels={n.channels}
-                                                           onRightChevronClick={() => this.navigateToNetworkDetail(n)}/>,
-        )}
-        <div>Lumino networks available</div>
-        {networks.withoutChannels.map(n => <LuminoNetworkItem key={n.symbol} symbol={n.symbol} nodes={n.nodes}
-                                                              channels={n.channels}
-                                                              onRightChevronClick={() => this.navigateToNetworkDetail(n)}/>,
-        )}
+        <GenericTable
+          title={'My Lumino Networks'}
+          columns={columns}
+          data={myNetworks}
+          paginationSize={3}/>
+        <GenericTable
+          title={'Lumino networks available'}
+          columns={columns}
+          data={otherNetworks}
+          paginationSize={3}/>
       </div>
     );
   }

--- a/ui/app/rif/pages/lumino/index.js
+++ b/ui/app/rif/pages/lumino/index.js
@@ -32,8 +32,8 @@ class LuminoHome extends Component {
 
   navigateToNetworkDetail = (network) => {
     const {navigateTo} = this.props;
-    const {symbol, networkAddress, name, networkTokenAddress} = network;
-    return navigateTo(symbol, networkAddress, name, networkTokenAddress)
+    const {symbol, tokenAddress, name, tokenNetwork} = network;
+    return navigateTo(symbol, tokenAddress, name, tokenNetwork)
   }
 
   getNetworkItems = networkArr => {
@@ -83,12 +83,12 @@ function mapStateToProps (state) {
 function mapDispatchToProps (dispatch) {
   return {
     getLuminoNetworks: (userAddress) => dispatch(rifActions.getLuminoNetworks(userAddress)),
-    navigateTo: (networkSymbol, networkAddress, networkName, networkTokenAddress) => {
+    navigateTo: (networkSymbol, tokenAddress, networkName, tokenNetwork) => {
       dispatch(rifActions.navigateTo(pageNames.lumino.networkDetails, {
         networkSymbol,
-        networkAddress,
+        tokenAddress,
         networkName,
-        networkTokenAddress,
+        tokenNetwork,
         tabOptions: {
           tabIndex: 1,
           showBack: true,

--- a/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
+++ b/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
@@ -12,6 +12,7 @@ class LuminoNetworkDetails extends Component {
     networkSymbol: PropTypes.string,
     networkAddress: PropTypes.string,
     getUserChannels: PropTypes.func,
+    getNetworkData: PropTypes.func,
     networkTokenAddress: PropTypes.string,
     networkName: PropTypes.string,
   }
@@ -29,9 +30,11 @@ class LuminoNetworkDetails extends Component {
   }
 
   reloadChannelsData = async () => {
-    const {getUserChannels, networkTokenAddress} = this.props;
+    const {getUserChannels, networkTokenAddress, getNetworkData} = this.props;
     const userChannels = await getUserChannels(networkTokenAddress);
-    if (userChannels && userChannels.length) return this.setState({userChannels, loading: false})
+    if (userChannels && userChannels.length) this.setState({userChannels, loading: false})
+    const networkData = await getNetworkData(networkTokenAddress);
+    if (networkData) this.setState({networkData})
   }
 
 
@@ -55,7 +58,7 @@ class LuminoNetworkDetails extends Component {
 
   render () {
     const {networkSymbol, networkName, networkAddress, networkTokenAddress} = this.props;
-    const {userChannels, loading} = this.state;
+    const {userChannels, loading, networkData} = this.state;
     const channelItems = this.getChannelItems(userChannels);
     const columns = [{
       Header: 'Content',
@@ -64,6 +67,17 @@ class LuminoNetworkDetails extends Component {
     return (
       <div className="body">
         <div>{networkSymbol} Network</div>
+        <div>
+          <div>
+            <img height={15} width={15} src="images/rif/node.svg"/>
+            {networkData.nodes} nodes
+          </div>
+          <div>
+            <img height={15} width={15} src="images/rif/node.svg"/>
+            {networkData.channels} channels
+          </div>
+
+        </div>
         <button>Leave</button>
         {loading && <div>Loading data</div>}
         {!loading && <div>
@@ -110,6 +124,7 @@ function mapStateToProps (state) {
 function mapDispatchToProps (dispatch) {
   return {
     getUserChannels: networkAddress => dispatch(rifActions.getUserChannelsInNetwork(networkAddress)),
+    getNetworkData: tokenAddress => dispatch(rifActions.getLuminoNetworkData(tokenAddress)),
   }
 }
 

--- a/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
+++ b/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
@@ -10,10 +10,10 @@ class LuminoNetworkDetails extends Component {
 
   static propTypes = {
     networkSymbol: PropTypes.string,
-    networkAddress: PropTypes.string,
+    tokenNetwork: PropTypes.string,
     getUserChannels: PropTypes.func,
     getNetworkData: PropTypes.func,
-    networkTokenAddress: PropTypes.string,
+    tokenAddress: PropTypes.string,
     networkName: PropTypes.string,
   }
 
@@ -30,10 +30,10 @@ class LuminoNetworkDetails extends Component {
   }
 
   reloadChannelsData = async () => {
-    const {getUserChannels, networkTokenAddress, getNetworkData} = this.props;
-    const userChannels = await getUserChannels(networkTokenAddress);
+    const {getUserChannels, tokenAddress, getNetworkData} = this.props;
+    const userChannels = await getUserChannels(tokenAddress);
     if (userChannels && userChannels.length) this.setState({userChannels, loading: false})
-    const networkData = await getNetworkData(networkTokenAddress);
+    const networkData = await getNetworkData(tokenAddress);
     if (networkData) this.setState({networkData})
   }
 
@@ -57,7 +57,7 @@ class LuminoNetworkDetails extends Component {
   }
 
   render () {
-    const {networkSymbol, networkName, networkAddress, networkTokenAddress} = this.props;
+    const {networkSymbol, networkName, tokenNetwork, tokenAddress} = this.props;
     const {userChannels, loading, networkData} = this.state;
     const channelItems = this.getChannelItems(userChannels);
     const columns = [{
@@ -98,8 +98,8 @@ class LuminoNetworkDetails extends Component {
         </div>
         }
         <OpenChannel
-          tokenAddress={networkTokenAddress}
-          tokenNetworkAddress={networkAddress}
+          tokenAddress={tokenAddress}
+          tokenNetworkAddress={tokenNetwork}
           tokenName={networkName}
           afterChannelCreated={this.reloadChannelsData}
           afterDepositCreated={this.reloadChannelsData}
@@ -115,15 +115,15 @@ function mapStateToProps (state) {
   return {
     currentAddress: state.metamask.selectedAddress.toLowerCase(),
     networkSymbol: params.networkSymbol,
-    networkAddress: params.networkAddress,
-    networkTokenAddress: params.networkTokenAddress,
+    tokenNetwork: params.tokenNetwork,
+    tokenAddress: params.tokenAddress,
     networkName: params.networkName,
   }
 }
 
 function mapDispatchToProps (dispatch) {
   return {
-    getUserChannels: networkAddress => dispatch(rifActions.getUserChannelsInNetwork(networkAddress)),
+    getUserChannels: tokenAddress => dispatch(rifActions.getUserChannelsInNetwork(tokenAddress)),
     getNetworkData: tokenAddress => dispatch(rifActions.getLuminoNetworkData(tokenAddress)),
   }
 }

--- a/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
+++ b/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux'
 import rifActions from '../../../actions';
 import LuminoChannelItem from '../../../components/luminoChannelItem';
 import OpenChannel from '../../../components/lumino/open-channel';
+import {GenericTable} from '../../../components';
 
 class LuminoNetworkDetails extends Component {
 
@@ -40,16 +41,39 @@ class LuminoNetworkDetails extends Component {
     return this.setState({loading: false})
   }
 
+  getChannelItems = channels => {
+    const {networkSymbol} = this.props;
+    return channels.map(c => {
+      return {
+        content: <LuminoChannelItem key={c.channel_identifier} partnerAddress={c.partner_address}
+                                    balance={c.balance}
+                                    state={c.state} tokenSymbol={networkSymbol}
+                                    onRightChevronClick={() => console.warn(c)}/>,
+      };
+    });
+  }
+
   render () {
     const {networkSymbol, networkName, networkAddress, networkTokenAddress} = this.props;
     const {userChannels, loading} = this.state;
+    const channelItems = this.getChannelItems(userChannels);
+    const columns = [{
+      Header: 'Content',
+      accessor: 'content',
+    }];
     return (
       <div className="body">
         <div>{networkSymbol} Network</div>
         <button>Leave</button>
         {loading && <div>Loading data</div>}
         {!loading && <div>
-          {userChannels.length && <div>My channels in the {networkSymbol} Network </div>}
+          {!!userChannels.length &&
+          <GenericTable
+            title={`My channels in ${networkSymbol} network`}
+            columns={columns}
+            data={channelItems}
+            paginationSize={3}/>
+          }
           {!userChannels.length && <div>
             <div>
               No channels yet
@@ -57,10 +81,6 @@ class LuminoNetworkDetails extends Component {
             <div>Add a channel to join the {networkSymbol} network</div>
           </div>
           }
-          {userChannels.map(c => <LuminoChannelItem key={c.channel_identifier} partnerAddress={c.partner_address}
-                                                    balance={c.balance}
-                                                    state={c.state} tokenSymbol={networkSymbol}
-                                                    onRightChevronClick={() => console.warn(c)}/>)}
         </div>
         }
         <OpenChannel


### PR DESCRIPTION
This PR includes the Next

- The Lumino networks are now using a table with pagination
- The Lumino channels of a network use a table as well
- For designing, mocks have been established in the actions (must be removed before merge with master)
- The missing section in the network detail with the nodes/channels has been added
- Some code has been cleaned up