### PR TITLE
Fix RIFEX-127 unique storage keys

### DIFF
--- a/app/scripts/controllers/rif/lumino/index.js
+++ b/app/scripts/controllers/rif/lumino/index.js
@@ -52,6 +52,7 @@ export class LuminoManager extends AbstractManager {
       }
       const luminoStorageHandler = new LuminoStorageHandler({
         store: this.store,
+        address: this.address,
       });
       const storageHandler = {
         getLuminoData: () => {

--- a/app/scripts/controllers/rif/lumino/storage.js
+++ b/app/scripts/controllers/rif/lumino/storage.js
@@ -1,18 +1,21 @@
 export class LuminoStorageHandler {
   constructor (props) {
     this.store = props.store;
+    this.address = props.address
   }
+
   getLuminoData () {
-    const unparsedData = this.store.getState().luminoData;
+    const unparsedData = this.store.getState()[`luminoData-${this.address}`];
     if (unparsedData) {
       return JSON.parse(unparsedData);
     }
     return null;
   }
+
   saveLuminoData (data) {
     if (data) {
       const state = this.store.getState();
-      state.luminoData = JSON.stringify(data);
+      state[`luminoData-${this.address}`] = JSON.stringify(data);
       this.store.putState(state);
     }
   }


### PR DESCRIPTION
This PR includes a simple change ,since LCs should not share their storage (api keys, payments, channels) all should be separated in a per account basis, I had to extend a little bit the LuminoStorageHandle class

- The class now takes the address
- The address is used to compose a unique string (address-luminoData)
- With this unique key, now the luminoData can be stored separately for every different account.
- This prevents issues with stalled apiKeys and possible mixed data (payments, channels)

