### PR TITLE
RIFEX-128 Fix search bar prop

### DIFF
--- a/ui/app/rif/components/searchDomains.js
+++ b/ui/app/rif/components/searchDomains.js
@@ -69,7 +69,7 @@ class SearchDomains extends Component {
   render () {
     return (
       <GenericSearch
-        filterFunction={this.filter}
+        customFilterFunction={this.filter}
         placeholder="Search for domains"
       />
     )


### PR DESCRIPTION
This is a subtle bug that makes the domain search not work.

The problem was that a prop was not set up properly.

This pr fixes that prop.