### PR TITLE
RIFEX-151 Search without enter in some inputs

### DIFF
--- a/ui/app/rif/components/genericSearch/index.js
+++ b/ui/app/rif/components/genericSearch/index.js
@@ -17,6 +17,7 @@ class GenericSearch extends Component {
     filterProperty: PropTypes.string,
     data: PropTypes.array,
     placeholder: PropTypes.string,
+    onlyFilterOnEnter: PropTypes.bool,
   }
 
   includesCriteria = (element, criteria) => {
@@ -26,8 +27,11 @@ class GenericSearch extends Component {
     return lowerElement.includes(lowerCriteria);
   }
 
-  handleKeyDown = async (e) => {
-    if (e.key === 'Enter') {
+  handleInput = async (e) => {
+    const {onlyFilterOnEnter} = this.props;
+    const enterPressed = e.key === 'Enter';
+    const shouldFilter = (!onlyFilterOnEnter && !enterPressed) || (onlyFilterOnEnter && enterPressed)
+    if (shouldFilter) {
       const {value} = e.target;
       const {customFilterFunction, resultSetFunction} = this.props;
 
@@ -52,13 +56,16 @@ class GenericSearch extends Component {
   }
 
   render () {
-    const {placeholder} = this.props;
+    const {placeholder, onlyFilterOnEnter} = this.props;
+    const handleKeydown = onlyFilterOnEnter ? this.handleInput : null;
+    const handleOnChange = onlyFilterOnEnter ? null : this.handleInput;
     return (
       <div className="search-bar-container">
         <input
           placeholder={placeholder || ''}
           className={'search-bar'}
-          onKeyDown={this.handleKeyDown}
+          onChange={handleOnChange}
+          onKeyDown={handleKeydown}
         />
       </div>
     )

--- a/ui/app/rif/components/searchDomains.js
+++ b/ui/app/rif/components/searchDomains.js
@@ -69,6 +69,7 @@ class SearchDomains extends Component {
   render () {
     return (
       <GenericSearch
+        onlyFilterOnEnter={true}
         customFilterFunction={this.filter}
         placeholder="Search for domains"
       />

--- a/ui/app/rif/components/subDomains.js
+++ b/ui/app/rif/components/subDomains.js
@@ -98,14 +98,14 @@ class Subdomains extends Component {
     const data = this.getData();
     return (
       <div className="subdomain-section">
+        <GenericSearch
+          placeholder={'Subdomains'}
+          data={subdomains}
+          resultSetFunction={this.setFilteredSubdomains}
+          filterProperty={'name'}/>
         {
           data.length > 0 &&
           <div>
-            <GenericSearch
-              placeholder={'Subdomains'}
-              data={subdomains}
-              resultSetFunction={this.setFilteredSubdomains}
-              filterProperty={'name'}/>
             <GenericTable
               columns={[
                 {

--- a/ui/app/rif/utils/utils.js
+++ b/ui/app/rif/utils/utils.js
@@ -1,8 +1,8 @@
 // Constant names, if you want to add a new token (icon), just go to constant.js and add one to the array, then add it to getNameTokenForIcon
-import { SLIP_ADDRESSES } from '../constants/slipAddresses'
+import {SLIP_ADDRESSES} from '../constants/slipAddresses'
 
 const getChainAddressByChainAddress = function (chainAddress) {
-    return SLIP_ADDRESSES.find(e => e.chain === chainAddress);
+  return SLIP_ADDRESSES.find(e => e.chain === chainAddress);
 }
 
 const getStatusForChannel = (SDK_STATUS) => {
@@ -14,7 +14,7 @@ const getStatusForChannel = (SDK_STATUS) => {
   }
 }
 const sumValuesOfArray = (items, prop) => {
-  return items.reduce( function(a, b){
+  return items.reduce(function (a, b) {
     return a + b[prop];
   }, 0);
 };


### PR DESCRIPTION
This PR includes a behaviour change for the GenericSearchBar

- Now it filters with every key press
- If it is explicitly declared to use enter to filter, it will do it so
- I fixed the search bar in subdomains (it was being unmounted on no results)
- The onChange event is used on filters without enter
- The onKeyDown event is used on filters with enter
- They are conditionally selected (to prevent double handling)

Solves RIFEX-151