### PR TITLE
RIFEX-158 Show Off chain balance

### DIFF
--- a/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
+++ b/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
@@ -20,7 +20,7 @@ const styles = {
       inactivePageButton: 'n-table-pagination-inactive',
       buttonNext: 'n-table-pagination-next',
     },
-  }
+  },
 }
 
 class LuminoNetworkDetails extends Component {
@@ -67,7 +67,7 @@ class LuminoNetworkDetails extends Component {
     return channels.map(c => {
       return {
         content: <LuminoChannelItem key={c.channel_identifier} partnerAddress={c.partner_address}
-                                    balance={c.balance}
+                                    balance={c.offChainBalance}
                                     state={c.state} tokenSymbol={networkSymbol}
                                     onRightChevronClick={() => this.props.showChannelDetails({
                                       channel: c,


### PR DESCRIPTION
The lumino channel items were showing an incorrect balance.

The correct property was offChainBalance.

Now it is being used

Solves RIFEX-158