### PR TITLE
Bug/rifex 191/fixing nifty confirmation page

### DIFF
--- a/old-ui/app/conf-tx.js
+++ b/old-ui/app/conf-tx.js
@@ -43,7 +43,7 @@ function mapStateToProps (state) {
     tokensToSend: (screenParams && screenParams.tokensToSend),
     tokensTransferTo: (screenParams && screenParams.tokensTransferTo),
     isContractExecutionByUser: (screenParams && screenParams.isContractExecutionByUser),
-    afterApproval: screenParams.afterApproval,
+    callbacks: screenParams.callbacks,
   }
 }
 
@@ -161,7 +161,8 @@ ConfirmTxScreen.prototype.buyEth = function (address, isContractExecutionByUser,
 
 ConfirmTxScreen.prototype.sendTransaction = function (txData, event) {
   this.stopPropagation(event)
-  this.props.dispatch(actions.updateAndApproveTx(txData, this.props.afterApproval))
+  const afterApproval = this.props.callbacks ? this.props.callbacks.afterApproval : null;
+  this.props.dispatch(actions.updateAndApproveTx(txData, afterApproval))
   this._checkIfContractExecutionAndUnlockContract(txData)
 }
 
@@ -170,6 +171,14 @@ ConfirmTxScreen.prototype.cancelTransaction = function (txData, event) {
   event.preventDefault()
   this.props.dispatch(actions.cancelTx(txData))
   this._checkIfContractExecutionAndUnlockContract(txData)
+  const callbacks = this.props.callbacks
+  if (callbacks && callbacks.afterCancel) {
+    if (callbacks.afterCancel.payload) {
+      callbacks.afterCancel.action(callbacks.afterCancel.payload)
+    } else {
+      callbacks.afterCancel.action()
+    }
+  }
 }
 
 ConfirmTxScreen.prototype.cancelAllTransactions = function (unconfTxList, event) {
@@ -177,6 +186,14 @@ ConfirmTxScreen.prototype.cancelAllTransactions = function (unconfTxList, event)
   event.preventDefault()
   this.props.dispatch(actions.cancelAllTx(unconfTxList))
   this._checkIfMultipleContractExecutionAndUnlockContract(unconfTxList)
+  const callbacks = this.props.callbacks
+  if (callbacks && callbacks.afterCancel) {
+    if (callbacks.afterCancel.payload) {
+      callbacks.afterCancel.action(callbacks.afterCancel.payload)
+    } else {
+      callbacks.afterCancel.action()
+    }
+  }
 }
 
 ConfirmTxScreen.prototype.signMessage = function (msgData, event) {
@@ -268,13 +285,19 @@ ConfirmTxScreen.prototype._unlockContract = function (to) {
 }
 
 function warningIfExists (warning) {
-  if (warning &&
-     // Do not display user rejections on this screen:
-     warning.indexOf('User denied transaction signature') === -1) {
+  if (warning && warning.indexOf &&
+    // Do not display user rejections on this screen:
+    warning.indexOf('User denied transaction signature') === -1) {
     return h('.error', {
       style: {
         margin: 'auto',
       },
     }, warning)
+  } else if (warning && warning.error && warning.error.message) {
+    return h('.error', {
+      style: {
+        margin: 'auto',
+      },
+    }, warning.error.message)
   }
 }

--- a/old-ui/app/conf-tx.js
+++ b/old-ui/app/conf-tx.js
@@ -161,7 +161,7 @@ ConfirmTxScreen.prototype.buyEth = function (address, isContractExecutionByUser,
 
 ConfirmTxScreen.prototype.sendTransaction = function (txData, event) {
   this.stopPropagation(event)
-  const afterApproval = this.props.callbacks ? this.props.callbacks.afterApproval : null;
+  const afterApproval = this.props.callbacks ? this.props.callbacks.afterApproval : null
   this.props.dispatch(actions.updateAndApproveTx(txData, afterApproval))
   this._checkIfContractExecutionAndUnlockContract(txData)
 }
@@ -169,31 +169,17 @@ ConfirmTxScreen.prototype.sendTransaction = function (txData, event) {
 ConfirmTxScreen.prototype.cancelTransaction = function (txData, event) {
   this.stopPropagation(event)
   event.preventDefault()
-  this.props.dispatch(actions.cancelTx(txData))
+  const afterCancel = this.props.callbacks ? this.props.callbacks.afterCancel : null
+  this.props.dispatch(actions.cancelTx(txData, afterCancel))
   this._checkIfContractExecutionAndUnlockContract(txData)
-  const callbacks = this.props.callbacks
-  if (callbacks && callbacks.afterCancel) {
-    if (callbacks.afterCancel.payload) {
-      callbacks.afterCancel.action(callbacks.afterCancel.payload)
-    } else {
-      callbacks.afterCancel.action()
-    }
-  }
 }
 
 ConfirmTxScreen.prototype.cancelAllTransactions = function (unconfTxList, event) {
   this.stopPropagation(event)
   event.preventDefault()
-  this.props.dispatch(actions.cancelAllTx(unconfTxList))
+  const afterCancel = this.props.callbacks ? this.props.callbacks.afterCancel : null
+  this.props.dispatch(actions.cancelAllTx(unconfTxList, afterCancel))
   this._checkIfMultipleContractExecutionAndUnlockContract(unconfTxList)
-  const callbacks = this.props.callbacks
-  if (callbacks && callbacks.afterCancel) {
-    if (callbacks.afterCancel.payload) {
-      callbacks.afterCancel.action(callbacks.afterCancel.payload)
-    } else {
-      callbacks.afterCancel.action()
-    }
-  }
 }
 
 ConfirmTxScreen.prototype.signMessage = function (msgData, event) {

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -146,7 +146,7 @@ function checkDomainAvailable (domainName) {
       background.rif.rns.resolver.isDomainAvailable(domainName, (error, available) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(available);
@@ -163,7 +163,7 @@ function getDomainDetails (domainName) {
         console.debug('This are the details bringed', details);
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(details);
@@ -182,7 +182,7 @@ function getDomainByAddress (address) {
       background.rif.rns.resolver.getAddressDomain(address, (error, domain) => {
         console.debug('this is the domain bringed', domain);
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(domain);
@@ -198,7 +198,7 @@ function setResolverAddress (domainName, resolverAddress) {
       background.rif.rns.resolver.setResolver(domainName, resolverAddress, (error, transactionListenerId) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(transactionListenerId);
@@ -212,7 +212,7 @@ function getResolverAddress (domainName) {
     return new Promise((resolve, reject) => {
       background.rif.rns.resolver.getResolver(domainName, (error, resolverAddress) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(resolverAddress);
@@ -228,7 +228,7 @@ function setChainAddressForResolver (domainName, chain, chainAddress, subdomain 
       background.rif.rns.resolver.setChainAddressForResolver(domainName, chain, chainAddress, subdomain, action, (error, result) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(result);
@@ -241,7 +241,7 @@ function deletePendingChainAddress (chain, isSubdomain) {
     return new Promise((resolve, reject) => {
       background.rif.rns.resolver.deletePendingChainAddress(chain, isSubdomain, (error, result) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(result);
@@ -255,7 +255,7 @@ function deletePendingSubdomain (domainName, subdomain) {
     return new Promise((resolve, reject) => {
       background.rif.rns.register.deletePendingSubdomain(domainName, subdomain, (error, result) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(result);
@@ -269,7 +269,7 @@ function getChainAddresses (domainName, subdomain = '') {
     return new Promise((resolve, reject) => {
       background.rif.rns.resolver.getChainAddressForResolvers(domainName, subdomain, (error, result) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(result);
@@ -285,7 +285,7 @@ function requestDomainRegistration (domainName, yearsToRegister) {
       background.rif.rns.register.requestRegistration(domainName, yearsToRegister, (error, result) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(result);
@@ -301,7 +301,7 @@ function canFinishRegistration (commitmentHash) {
       background.rif.rns.register.canFinishRegistration(commitmentHash, (error, result) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(result);
@@ -317,7 +317,7 @@ function finishRegistration (domainName) {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.finishRegistration(domainName, (error, transactionListenerId) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
         }
         return resolve(transactionListenerId);
       });
@@ -332,7 +332,7 @@ function getRegistrationCost (domainName, yearsToRegister) {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.getDomainCost(domainName, yearsToRegister, (error, result) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(result);
@@ -348,7 +348,7 @@ function getUnapprovedTransactions () {
       background.rif.rns.register.getUnapprovedTransactions((error, transactions) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(transactions);
@@ -364,7 +364,7 @@ function getSelectedAddress () {
       background.rif.rns.register.getSelectedAddress((error, selectedAddress) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(selectedAddress);
@@ -477,7 +477,7 @@ function getSubdomains (domainName) {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.getSubdomainsForDomain(domainName, (error, result) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(result);
@@ -491,7 +491,7 @@ function waitForTransactionListener (transactionListenerId) {
     return new Promise((resolve, reject) => {
       background.rif.rns.register.waitForTransactionListener(transactionListenerId, (error, transactionReceipt) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(transactionReceipt);
@@ -507,7 +507,7 @@ function createSubdomain (domainName, subdomain, ownerAddress, parentOwnerAddres
       background.rif.rns.register.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress, (error, transactionListenerId) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(transactionListenerId);
@@ -523,7 +523,7 @@ function isSubdomainAvailable (domainName, subdomain) {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.isSubdomainAvailable(domainName, subdomain, (error, available) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(available);
@@ -532,7 +532,7 @@ function isSubdomainAvailable (domainName, subdomain) {
   };
 }
 
-function goToConfirmPageForLastTransaction (afterApproval) {
+function goToConfirmPageForLastTransaction (callbacks) {
   return (dispatch) => {
     dispatch(waitUntil()).then(() => {
       dispatch(getUnapprovedTransactions())
@@ -540,7 +540,7 @@ function goToConfirmPageForLastTransaction (afterApproval) {
           dispatch(niftyActions.showConfTxPage({
             id: latestTransaction.id,
             unapprovedTransactions: latestTransaction,
-            afterApproval,
+            callbacks,
           }));
         });
     });
@@ -554,7 +554,7 @@ function deleteSubdomain (domainName, subdomain) {
       background.rif.rns.register.deleteSubdomain(domainName, subdomain, (error, transactionListenerId) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(transactionListenerId);
@@ -570,7 +570,7 @@ function getDomain (domainName) {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.getDomain(domainName, (error, domain) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(domain);
@@ -586,7 +586,7 @@ function getDomainAddress (domainName) {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.getDomainAddress(domainName, (error, domainAddress) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(domainAddress);
@@ -602,7 +602,7 @@ function getDomains () {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.getDomains((error, domains) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(domains);
@@ -618,7 +618,7 @@ function updateDomains (domain) {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.updateDomain(domain, (error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -640,7 +640,7 @@ function onboarding (callbackHandlers = new CallbackHandlers()) {
       }
       background.rif.lumino.onboarding((error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -706,7 +706,7 @@ function getAvailableCallbacks () {
     return new Promise((resolve, reject) => {
       background.rif.lumino.getAvailableCallbacks((error, callbackNames) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(callbackNames);
@@ -729,7 +729,7 @@ function openChannel (partner, tokenAddress, callbackHandlers = new CallbackHand
       }
       background.rif.lumino.openChannel(partner, tokenAddress, (error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -752,7 +752,7 @@ function closeChannel (partner, tokenAddress, tokenNetworkAddress, channelIdenti
       }
       background.rif.lumino.closeChannel(partner, tokenAddress, tokenNetworkAddress, channelIdentifier, (error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -766,7 +766,7 @@ function deleteChannelFromSdk (channelIdentifier, tokenAddress) {
     return new Promise((resolve, reject) => {
       background.rif.lumino.deleteChannelFromSDK(channelIdentifier, tokenAddress, (error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -790,7 +790,7 @@ function createDeposit (partner, tokenAddress, tokenNetworkAddress, channelIdent
       }
       background.rif.lumino.createDeposit(partner, tokenAddress, tokenNetworkAddress, channelIdentifier, netAmount, (error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -821,7 +821,7 @@ function createPayment (partner, tokenAddress, netAmount, callbackHandlers = new
       }
       background.rif.lumino.createPayment(partner, tokenAddress, netAmount, (error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -835,7 +835,7 @@ function getChannels () {
     return new Promise((resolve, reject) => {
       background.rif.lumino.getChannels((error, channels) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error)
         }
         return resolve(channels);
@@ -860,7 +860,7 @@ function getChannelsGroupedByNetwork () {
         const groupedBy = _.groupBy(arrayWithoutKeys, 'token_network_identifier');
         return resolve(groupedBy);
       }).catch(error => {
-        dispatch(niftyActions.displayWarning(error));
+        handleError(error, dispatch);
         reject(error)
       });
     });
@@ -872,7 +872,7 @@ function getTokens () {
     return new Promise((resolve, reject) => {
       background.rif.lumino.getTokens((error, tokens) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(tokens);
@@ -886,7 +886,7 @@ function isLuminoNode (address) {
     return new Promise((resolve, reject) => {
       background.rif.lumino.isLuminoNode(address, (error, isLuminoNode) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(isLuminoNode);
@@ -1011,7 +1011,7 @@ function getUserChannelsInNetwork (tokenAddress) {
   return (dispatch) => new Promise((resolve, reject) => {
     background.rif.lumino.getChannels((error, channels) => {
       if (error) {
-        dispatch(niftyActions.displayWarning(error));
+        handleError(error, dispatch);
         return reject(error);
       }
       if (channels) {
@@ -1029,7 +1029,7 @@ function cleanStore () {
     return new Promise((resolve, reject) => {
       background.rif.cleanStore((error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -1139,7 +1139,7 @@ function subscribeToCloseChannel (channelId, tokenNetworkAddress) {
     return new Promise((resolve, reject) => {
       background.rif.lumino.subscribeToCloseChannel(channelId, tokenNetworkAddress, (error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -1153,7 +1153,7 @@ function getConfiguration () {
     return new Promise((resolve, reject) => {
       background.rif.getConfiguration((error, configuration) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(configuration);
@@ -1167,7 +1167,7 @@ function setConfiguration (configuration) {
     return new Promise((resolve, reject) => {
       background.rif.setConfiguration(configuration, (error) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve();
@@ -1181,7 +1181,7 @@ function rifEnabled () {
     return new Promise((resolve, reject) => {
       background.rif.enabled((error, enabled) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(enabled);
@@ -1195,13 +1195,25 @@ function walletUnlocked () {
     return new Promise((resolve, reject) => {
       background.rif.walletUnlocked((error, enabled) => {
         if (error) {
-          dispatch(niftyActions.displayWarning(error));
+          handleError(error, dispatch);
           return reject(error);
         }
         return resolve(enabled);
       });
     });
   };
+}
+
+function handleError (error, dispatch) {
+  if (error && dispatch) {
+    if (typeof error === 'string') {
+      dispatch(niftyActions.displayToast(error, false));
+    } else if (error.error && error.error.message) {
+      dispatch(niftyActions.displayToast(error.error.message, false));
+    } else {
+      dispatch(niftyActions.displayToast(JSON.stringify(error), false));
+    }
+  }
 }
 
 

--- a/ui/app/rif/components/chainAddresses.js
+++ b/ui/app/rif/components/chainAddresses.js
@@ -157,13 +157,15 @@ class ChainAddresses extends Component {
         }
       });
     this.props.showTransactionConfirmPage({
-      action: () => {
-        this.props.showThis(
-          this.props.redirectPage,
+      afterApproval: {
+        action: () => {
+          this.props.showThis(
+            this.props.redirectPage,
             this.props.redirectParams);
-        if (toastMessage) {
-          this.props.showToast(toastMessage);
-        }
+          if (toastMessage) {
+            this.props.showToast(toastMessage);
+          }
+        },
       },
     });
   }
@@ -249,7 +251,7 @@ function mapDispatchToProps (dispatch) {
     deletePendingChainAddress: (chain, isSubdomain) => dispatch(rifActions.deletePendingChainAddress(chain, isSubdomain)),
     showThis: (pageName, props) => dispatch(rifActions.navigateTo(pageName, props)),
     waitForListener: (transactionListenerId) => dispatch(rifActions.waitForTransactionListener(transactionListenerId)),
-    showTransactionConfirmPage: (afterApproval) => dispatch(rifActions.goToConfirmPageForLastTransaction(afterApproval)),
+    showTransactionConfirmPage: (callbacks) => dispatch(rifActions.goToConfirmPageForLastTransaction(callbacks)),
     getConfiguration: () => dispatch(rifActions.getConfiguration()),
     showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
     getResolverAddress: (domainName) => dispatch(rifActions.getResolverAddress(domainName)),

--- a/ui/app/rif/components/subDomains.js
+++ b/ui/app/rif/components/subDomains.js
@@ -23,7 +23,6 @@ class Subdomains extends Component {
     createSubdomain: PropTypes.func,
     waitForListener: PropTypes.func,
     showToast: PropTypes.func,
-    showTransactionConfirmPage: PropTypes.func,
     isSubdomainAvailable: PropTypes.func,
     showSubdomainDetails: PropTypes.func,
     newSubdomains: PropTypes.array,
@@ -181,7 +180,6 @@ function mapDispatchToProps (dispatch) {
     createSubdomain: (domainName, subdomain, ownerAddress, parentOwnerAddress) => dispatch(rifActions.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress)),
     waitForListener: (transactionListenerId) => dispatch(rifActions.waitForTransactionListener(transactionListenerId)),
     showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
-    showTransactionConfirmPage: (afterApproval) => dispatch(rifActions.goToConfirmPageForLastTransaction(afterApproval)),
     isSubdomainAvailable: (domainName, subdomain) => dispatch(rifActions.isSubdomainAvailable(domainName, subdomain)),
   }
 }

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/addNewSubdomain/index.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/addNewSubdomain/index.js
@@ -50,15 +50,17 @@ class AddNewSubdomain extends Component {
       hideCancel: true,
       confirmCallback: async () => {
         this.props.showTransactionConfirmPage({
-          action: (payload) => {
-            this.props.showThis(
-              this.props.pageName,
-              {
-                ...this.props.redirectParams,
-              });
-            this.props.showToast('Waiting Confirmation');
+          afterApproval: {
+            action: (payload) => {
+              this.props.showThis(
+                this.props.pageName,
+                {
+                  ...this.props.redirectParams,
+                });
+              this.props.showToast('Waiting Confirmation');
+            },
+            payload: null,
           },
-          payload: null,
         });
       },
     });
@@ -104,7 +106,7 @@ function mapDispatchToProps (dispatch) {
     getSubdomains: (domainName) => dispatch(rifActions.getSubdomains(domainName)),
     waitForListener: (transactionListenerId) => dispatch(rifActions.waitForTransactionListener(transactionListenerId)),
     showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
-    showTransactionConfirmPage: (afterApproval) => dispatch(rifActions.goToConfirmPageForLastTransaction(afterApproval)),
+    showTransactionConfirmPage: (callbacks) => dispatch(rifActions.goToConfirmPageForLastTransaction(callbacks)),
     deletePendingSubdomain: (domainName, subdomain) => dispatch(rifActions.deletePendingSubdomain(domainName, subdomain)),
   }
 }

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
@@ -66,13 +66,15 @@ class DomainsDetailConfigurationScreen extends Component {
             });
           });
         this.props.showTransactionConfirmPage({
-          action: () => {
-            this.props.showDomainConfigPage({
-              ...this.props,
-              disableSelect: true,
-              selectedResolverAddress: address,
-            });
-            this.props.showToast('Waiting Confirmation');
+          afterApproval: {
+            action: () => {
+              this.props.showDomainConfigPage({
+                ...this.props,
+                disableSelect: true,
+                selectedResolverAddress: address,
+              });
+              this.props.showToast('Waiting Confirmation');
+            },
           },
         });
         return;
@@ -135,7 +137,7 @@ const mapDispatchToProps = dispatch => {
     showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
     waitForListener: (transactionListenerId) => dispatch(rifActions.waitForTransactionListener(transactionListenerId)),
     setNewResolver: (domainName, resolverAddress) => dispatch(rifActions.setResolverAddress(domainName, resolverAddress)),
-    showTransactionConfirmPage: (afterApproval) => dispatch(rifActions.goToConfirmPageForLastTransaction(afterApproval)),
+    showTransactionConfirmPage: (callbacks) => dispatch(rifActions.goToConfirmPageForLastTransaction(callbacks)),
     showDomainConfigPage: (props) => dispatch(rifActions.navigateTo(pageNames.rns.domainsDetailConfiguration, props)),
     getConfiguration: () => dispatch(rifActions.getConfiguration()),
   }

--- a/ui/app/rif/pages/rns/register/index.js
+++ b/ui/app/rif/pages/rns/register/index.js
@@ -124,7 +124,9 @@ class DomainRegisterScreen extends Component {
         this.showWaitingForRegister();
       });
     this.props.showTransactionConfirmPage({
-      action: () => this.showWaitingForConfirmation(),
+      afterApproval: {
+        action: () => this.showWaitingForConfirmation(),
+      },
     });
   }
 
@@ -135,7 +137,9 @@ class DomainRegisterScreen extends Component {
         this.afterRegistration();
       });
     this.props.showTransactionConfirmPage({
-      action: () => this.afterRegistrationSubmit(),
+      afterApproval: {
+        action: () => this.afterRegistrationSubmit(),
+      },
     });
   }
 
@@ -317,7 +321,7 @@ const mapDispatchToProps = dispatch => {
     getCost: (domainName, yearsToRegister) => dispatch(rifActions.getRegistrationCost(domainName, yearsToRegister)),
     requestRegistration: (domainName, yearsToRegister) => dispatch(rifActions.requestDomainRegistration(domainName, yearsToRegister)),
     getUnapprovedTransactions: () => dispatch(rifActions.getUnapprovedTransactions()),
-    showTransactionConfirmPage: (afterApproval) => dispatch(rifActions.goToConfirmPageForLastTransaction(afterApproval)),
+    showTransactionConfirmPage: (callbacks) => dispatch(rifActions.goToConfirmPageForLastTransaction(callbacks)),
     completeRegistration: (domainName) => dispatch(rifActions.finishRegistration(domainName)),
     canCompleteRegistration: (commitment) => dispatch(rifActions.canFinishRegistration(commitment)),
     waitForListener: (transactionListenerId) => dispatch(rifActions.waitForTransactionListener(transactionListenerId)),

--- a/ui/app/rif/pages/rns/subdomains/index.js
+++ b/ui/app/rif/pages/rns/subdomains/index.js
@@ -122,17 +122,19 @@ class Subdomains extends Component {
             });
         });
         this.props.showTransactionConfirmPage({
-          action: () => {
-            this.props.getSubdomains(this.props.domainName)
-              .then(subdomains => {
-                this.props.showThis(
-                  this.props.pageName,
-                  {
-                    ...this.props.redirectParams,
-                    newSubdomains: subdomains,
-                  });
-              });
-            this.props.showToast('Waiting for confirmation');
+          afterApproval: {
+            action: () => {
+              this.props.getSubdomains(this.props.domainName)
+                .then(subdomains => {
+                  this.props.showThis(
+                    this.props.pageName,
+                    {
+                      ...this.props.redirectParams,
+                      newSubdomains: subdomains,
+                    });
+                });
+              this.props.showToast('Waiting for confirmation');
+            },
           },
         });
       },
@@ -215,7 +217,7 @@ function mapDispatchToProps (dispatch) {
     createSubdomain: (domainName, subdomain, ownerAddress, parentOwnerAddress) => dispatch(rifActions.createSubdomain(domainName, subdomain, ownerAddress, parentOwnerAddress)),
     waitForListener: (transactionListenerId) => dispatch(rifActions.waitForTransactionListener(transactionListenerId)),
     showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
-    showTransactionConfirmPage: (afterApproval) => dispatch(rifActions.goToConfirmPageForLastTransaction(afterApproval)),
+    showTransactionConfirmPage: (callbacks) => dispatch(rifActions.goToConfirmPageForLastTransaction(callbacks)),
     isSubdomainAvailable: (domainName, subdomain) => dispatch(rifActions.isSubdomainAvailable(domainName, subdomain)),
     deleteSubdomain: (domainName, subdomain) => dispatch(rifActions.deleteSubdomain(domainName, subdomain)),
     deletePendingSubdomain: (domainName, subdomain) => dispatch(rifActions.deletePendingSubdomain(domainName, subdomain)),


### PR DESCRIPTION
This PR fixes the rejections of rif transactions for RNS. Basically we fix the blank page and handle the rejection by adding support for cancel callbacks.

This affects only the ui layer.

Here a demo:

![demo](https://user-images.githubusercontent.com/7540348/86942436-8487ee00-c11b-11ea-9d1f-e5919c1954df.gif)
