### PR TITLE
RIFEX-223/Missed-inicialization-pendingChainAddresses

### DIFF
--- a/app/scripts/controllers/rif/rns/rnsjs-delegate.js
+++ b/app/scripts/controllers/rif/rns/rnsjs-delegate.js
@@ -306,6 +306,7 @@ export default class RnsJsDelegate extends RnsDelegate {
     return {
       name: domainName,
       subdomains: [],
+      pendingChainAddresses: [],
       registration: {
         secret: null,
         yearsToRegister: null,


### PR DESCRIPTION
This PR fixes the bug, that's a missing inicialization for the pendingchainaddresses array. That happends when you create a domain. 