### PR TITLE
RIFEX-239 Correct operation times

### DIFF
--- a/ui/app/rif/components/lumino/deposit-on-channel/index.js
+++ b/ui/app/rif/components/lumino/deposit-on-channel/index.js
@@ -101,7 +101,7 @@ class DepositOnChannel extends Component {
           }
           this.setState({
             loading: true,
-            loadingMessage: 'Making deposit\nPlease wait, this operation could take around 6 minutes.',
+            loadingMessage: 'Making deposit\nPlease wait, this operation could take around 4 minutes.',
           });
           await this.props.createDeposit(
             this.props.destination,

--- a/ui/app/rif/components/lumino/deposit-on-channel/index.js
+++ b/ui/app/rif/components/lumino/deposit-on-channel/index.js
@@ -101,7 +101,7 @@ class DepositOnChannel extends Component {
           }
           this.setState({
             loading: true,
-            loadingMessage: 'Making deposit\nPlease wait, this operation could take around 4 minutes.',
+            loadingMessage: 'Making deposit\nPlease wait, this operation could take around 8 minutes.',
           });
           await this.props.createDeposit(
             this.props.destination,

--- a/ui/app/rif/components/lumino/open-channel/index.js
+++ b/ui/app/rif/components/lumino/open-channel/index.js
@@ -208,7 +208,7 @@ class OpenChannel extends Component {
       if (this.state.amount) {
         this.setState({
           loading: true,
-          loadingMessage: 'Making deposit\nPlease wait, this operation could take around 4 minutes',
+          loadingMessage: 'Making deposit\nPlease wait, this operation could take around 8 minutes',
         });
         const depositCallbackHandlers = new CallbackHandlers();
         depositCallbackHandlers.requestHandler = (result) => {

--- a/ui/app/rif/components/lumino/open-channel/index.js
+++ b/ui/app/rif/components/lumino/open-channel/index.js
@@ -208,7 +208,7 @@ class OpenChannel extends Component {
       if (this.state.amount) {
         this.setState({
           loading: true,
-          loadingMessage: 'Making deposit\nPlease wait, this operation could take around 6 minutes',
+          loadingMessage: 'Making deposit\nPlease wait, this operation could take around 4 minutes',
         });
         const depositCallbackHandlers = new CallbackHandlers();
         depositCallbackHandlers.requestHandler = (result) => {


### PR DESCRIPTION
When we show an user the spinner with the appropriate time, we thought that deposits took 6 minutes, but in reality they take 8.

This PR includes a fix for those messages