### PR TITLE
RIFEX-242/Setting-multichain-back-action

### DIFF
--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
@@ -124,6 +124,7 @@ class DomainsDetailActiveScreen extends Component {
     getConfiguration: PropTypes.func,
     isLuminoNode: PropTypes.func,
     showPay: PropTypes.func,
+    getResolverAddress: PropTypes.func
   }
 
   constructor (props) {
@@ -140,15 +141,22 @@ class DomainsDetailActiveScreen extends Component {
         isLuminoNode: isLumino,
       });
     });
+    this.props.getResolverAddress(this.props.domainName)
+      .then(resolverAddress => {
+        this.setState({
+          selectedResolverAddress: resolverAddress.toLowerCase(),
+        });
+      });
     this.state = {
       resolvers: [],
       isLuminoNode: false,
+      selectedResolverAddress: '',
     };
   }
 
   render () {
-    const {domain, domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, selectedResolverAddress, newChainAddresses, newSubdomains, showPay } = this.props;
-    const {resolvers, isLuminoNode} = this.state;
+    const {domain, domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, newChainAddresses, newSubdomains, showPay } = this.props;
+    const {resolvers, isLuminoNode, selectedResolverAddress} = this.state;
     const domainInfo = {
       domainName,
       expirationDate,
@@ -277,6 +285,7 @@ const mapDispatchToProps = dispatch => {
     showPay: (domainInfo) => dispatch(rifActions.navigateTo(pageNames.rns.pay, {
       domainInfo: domainInfo,
     })),
+    getResolverAddress: (domainName) => dispatch(rifActions.getResolverAddress(domainName)),
   }
 }
 

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
@@ -124,7 +124,7 @@ class DomainsDetailActiveScreen extends Component {
     getConfiguration: PropTypes.func,
     isLuminoNode: PropTypes.func,
     showPay: PropTypes.func,
-    getResolverAddress: PropTypes.func
+    getResolverAddress: PropTypes.func,
   }
 
   constructor (props) {
@@ -253,7 +253,6 @@ function mapStateToProps (state) {
     ownerAddress: details.ownerAddress,
     isOwner: state.metamask.selectedAddress.toLowerCase() === details.ownerAddress.toLowerCase(),
     isRifStorage: details.isRifStorage,
-    selectedResolverAddress: params.selectedResolverAddress ? params.selectedResolverAddress : details.selectedResolverAddress,
     newChainAddresses: details.newChainAddresses || [],
     newSubdomains: params.newSubdomains || details.newSubdomains || [],
     disableResolvers: details.disableResolvers,


### PR DESCRIPTION
This PR fixes a BUG that happends when you set a resolver, go back and the you go back to the config again. (It was showing the old resolver)