### PR TITLE
RIFEX-251/NotOwner-Not-showing-chainaddresses

### DIFF
--- a/app/scripts/controllers/rif/rns/resolver/index.js
+++ b/app/scripts/controllers/rif/rns/resolver/index.js
@@ -158,7 +158,8 @@ export default class RnsResolver extends RnsJsDelegate {
       const chainAddrChangedEvent = await this.notifierManager.operations.getRnsEvents(this.notifierManager.apiKey, node, 'ChainAddrChanged');
       const arrChains = [];
       const domain = this.getDomain(domainName);
-      const pendingChainAddressesActions = domain.pendingChainAddresses;
+      // If we're not owners of the domain, the getdomain function will retrieve undefined
+      const pendingChainAddressesActions = (domain && domain.pendingChainAddresses) ? domain.pendingChainAddresses : [];
       if (addrChangedEvent) {
         addrChangedEvent.forEach(event => {
           if (event.address !== rns.zeroAddress) {


### PR DESCRIPTION
This PR fixes that when you access to a domain that you're not the owner, it was not showing the chainaddresses

![image](https://user-images.githubusercontent.com/35036353/87584039-422e5600-c6b3-11ea-8a8e-9b037934ecf5.png)
