### PR TITLE
RIFEX-248/Clicking-domain-tab

### DIFF
--- a/ui/app/rif/components/tabs/index.js
+++ b/ui/app/rif/components/tabs/index.js
@@ -21,11 +21,13 @@ class Tabs extends Component {
   }
 
   selectTab (tab) {
-    this.setState({
-      activeTabIndex: tab.index,
-    });
-    if (this.props.onChange) {
-      this.props.onChange(tab);
+    if (tab.index !== this.state.activeTabIndex) {
+      this.setState({
+        activeTabIndex: tab.index,
+      });
+      if (this.props.onChange) {
+        this.props.onChange(tab);
+      }
     }
   }
 

--- a/ui/app/rif/pages/domainsPage/domainsPage.js
+++ b/ui/app/rif/pages/domainsPage/domainsPage.js
@@ -21,6 +21,16 @@ class DomainsScreen extends Component {
 
   async componentDidMount () {
     if (!this.props.domains) {
+      this.loadDomains();
+    }
+  }
+  async componentDidUpdate (prevProps, prevState, snapshot) {
+    if (!this.props.domains) {
+      this.loadDomains();
+    }
+  }
+  async loadDomains() {
+    if (!this.props.domains) {
       const domains = await this.props.getDomains();
       this.props.showThis({
         ...this.props,
@@ -125,7 +135,17 @@ const mapDispatchToProps = dispatch => {
       ...data,
     })),
     setAutoRenew: (data) => {},
-    showThis: (params) => dispatch(rifActions.navigateTo(pageNames.rns.domains, params)),
+    showThis: (params) => dispatch(rifActions.navigateTo(pageNames.rns.domains, {
+      ...params,
+      tabOptions: {
+        title: 'My Domains',
+        index: 0,
+        defaultScreenTitle: 'My Domains',
+        defaultScreenName: pageNames.rns.domains,
+        showTitle: true,
+        showSearchbar: true,
+      },
+    })),
     getDomains: () => dispatch(rifActions.getDomains()),
   }
 }

--- a/ui/app/rif/pages/domainsPage/domainsPage.js
+++ b/ui/app/rif/pages/domainsPage/domainsPage.js
@@ -21,16 +21,6 @@ class DomainsScreen extends Component {
 
   async componentDidMount () {
     if (!this.props.domains) {
-      this.loadDomains();
-    }
-  }
-  async componentDidUpdate (prevProps, prevState, snapshot) {
-    if (!this.props.domains) {
-      this.loadDomains();
-    }
-  }
-  async loadDomains() {
-    if (!this.props.domains) {
       const domains = await this.props.getDomains();
       this.props.showThis({
         ...this.props,
@@ -138,7 +128,7 @@ const mapDispatchToProps = dispatch => {
     showThis: (params) => dispatch(rifActions.navigateTo(pageNames.rns.domains, {
       ...params,
       tabOptions: {
-        title: 'My Domains',
+        screenTitle: 'My Domains',
         index: 0,
         defaultScreenTitle: 'My Domains',
         defaultScreenName: pageNames.rns.domains,


### PR DESCRIPTION
This PR fixes that when you click on domain tab, and you're already on there, the domains will disappear (Because of losing of props)