### PR TITLE
RIFEX-260/Indicator-Pending-Set-Resolver

### DIFF
--- a/app/scripts/controllers/rif/rns/resolver/index.js
+++ b/app/scripts/controllers/rif/rns/resolver/index.js
@@ -149,6 +149,9 @@ export default class RnsResolver extends RnsJsDelegate {
           });
           console.debug('setResolver success', result);
         }).catch(result => {
+          const domain = this.getDomain(domainName, result.address, result.network);
+          domain.pendingActions.pendingSetResolver = false;
+          this.updateDomain(domain, result.address, result.network);
           console.debug('Error when trying to set resolver', result);
         });
       resolve(transactionListener.id);
@@ -173,7 +176,7 @@ export default class RnsResolver extends RnsJsDelegate {
       const arrChains = [];
       const domain = this.getDomain(domainName);
       // If we're not owners of the domain, the getdomain function will retrieve undefined
-      const pendingChainAddressesActions = (domain && domain.pendingActions && domain.pendingActions.chainAddresses) ? domain.pendingActions.pendingChainAddresses : [];
+      const pendingChainAddressesActions = (domain && domain.pendingActions && domain.pendingActions.chainAddresses) ? domain.pendingActions.chainAddresses : [];
       if (addrChangedEvent) {
         addrChangedEvent.forEach(event => {
           if (event.address !== rns.zeroAddress) {
@@ -225,7 +228,7 @@ export default class RnsResolver extends RnsJsDelegate {
   deletePendingChainAddress (domainName, chain, nodeHash, address, network) {
     return new Promise((resolve, reject) => {
       const domain = this.getDomain(domainName, address, network);
-      const pendingChainAddressesActions = domain.pendingActions.pendingChainAddresses;
+      const pendingChainAddressesActions = domain.pendingActions.chainAddresses;
       const index = pendingChainAddressesActions.findIndex((e) => e.chain === chain && e.nodeHash === nodeHash);
       if (index >= 0) {
         pendingChainAddressesActions.splice(index, 1);
@@ -253,7 +256,7 @@ export default class RnsResolver extends RnsJsDelegate {
       }
       const toBeSettedChainAddress = chainAddress || rns.zeroAddress;
       const domain = this.getDomain(domainName);
-      const pendingChainAddressesActions = domain.pendingActions.pendingChainAddresses;
+      const pendingChainAddressesActions = domain.pendingActions.chainAddresses;
       pendingChainAddressesActions.push({
         chainAddress: toBeSettedChainAddress,
         chain: chain,

--- a/app/scripts/controllers/rif/rns/rnsjs-delegate.js
+++ b/app/scripts/controllers/rif/rns/rnsjs-delegate.js
@@ -312,7 +312,10 @@ export default class RnsJsDelegate extends RnsDelegate {
     return {
       name: domainName,
       subdomains: [],
-      pendingChainAddresses: [],
+      pendingActions: {
+        chainAddresses: [],
+        pendingSetResolver: false,
+      },
       registration: {
         secret: null,
         yearsToRegister: null,

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -19,7 +19,7 @@ const rifActions = {
   checkDomainAvailable,
   getDomainDetails,
   setResolverAddress,
-  getResolverAddress,
+  getResolver,
   getChainAddresses,
   setChainAddressForResolver,
   deletePendingChainAddress,
@@ -207,15 +207,15 @@ function setResolverAddress (domainName, resolverAddress) {
   }
 }
 
-function getResolverAddress (domainName) {
+function getResolver (domainName) {
   return (dispatch) => {
     return new Promise((resolve, reject) => {
-      background.rif.rns.resolver.getResolver(domainName, (error, resolverAddress) => {
+      background.rif.rns.resolver.getResolver(domainName, (error, resolver) => {
         if (error) {
           handleError(error, dispatch);
           return reject(error);
         }
-        return resolve(resolverAddress);
+        return resolve(resolver);
       });
     })
   }

--- a/ui/app/rif/components/chainAddresses.js
+++ b/ui/app/rif/components/chainAddresses.js
@@ -33,7 +33,7 @@ class ChainAddresses extends Component {
     classes: PropTypes.any,
     getConfiguration: PropTypes.func,
     showToast: PropTypes.func,
-    getResolverAddress: PropTypes.func,
+    getResolver: PropTypes.func,
   }
 
   constructor (props) {
@@ -45,10 +45,10 @@ class ChainAddresses extends Component {
           resolvers,
         });
       });
-    this.props.getResolverAddress(this.props.domainName)
-      .then(resolverAddress => {
+    this.props.getResolver(this.props.domainName)
+      .then(resolver => {
         this.setState({
-          selectedResolverAddress: resolverAddress.toLowerCase(),
+          selectedResolverAddress: resolver.address.toLowerCase(),
         });
       });
     const slipChainAddressesOrdered = Object.assign([], lodash.orderBy(SLIP_ADDRESSES, ['name'], ['asc']));
@@ -268,7 +268,7 @@ function mapDispatchToProps (dispatch) {
     showTransactionConfirmPage: (callbacks) => dispatch(rifActions.goToConfirmPageForLastTransaction(callbacks)),
     getConfiguration: () => dispatch(rifActions.getConfiguration()),
     showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
-    getResolverAddress: (domainName) => dispatch(rifActions.getResolverAddress(domainName)),
+    getResolver: (domainName) => dispatch(rifActions.getResolver(domainName)),
   }
 }
 module.exports = connect(mapStateToProps, mapDispatchToProps)(ChainAddresses);

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
@@ -157,7 +157,7 @@ class DomainsDetailActiveScreen extends Component {
   render () {
     const {domain, domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, newChainAddresses, newSubdomains, showPay } = this.props;
     const {resolvers, isLuminoNode, resolver} = this.state;
-    const selectedResolverAddress = resolver.address.toLowerCase();
+    const selectedResolverAddress = resolver ? resolver.address.toLowerCase() : '';
     const domainInfo = {
       domainName,
       expirationDate,
@@ -185,7 +185,7 @@ class DomainsDetailActiveScreen extends Component {
                    domain: domain,
                    domainName: domainName,
                    selectedResolverAddress: selectedResolverAddress,
-                   isPending: resolver.pending,
+                   disableSelect: resolver.pending,
                  })}
             >
               <line x1="16" y1="4.37114e-08" x2="16" y2="23" stroke="#602A95" strokeWidth="2"/>

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
@@ -124,7 +124,7 @@ class DomainsDetailActiveScreen extends Component {
     getConfiguration: PropTypes.func,
     isLuminoNode: PropTypes.func,
     showPay: PropTypes.func,
-    getResolverAddress: PropTypes.func,
+    getResolver: PropTypes.func,
   }
 
   constructor (props) {
@@ -141,22 +141,23 @@ class DomainsDetailActiveScreen extends Component {
         isLuminoNode: isLumino,
       });
     });
-    this.props.getResolverAddress(this.props.domainName)
-      .then(resolverAddress => {
+    this.props.getResolver(this.props.domainName)
+      .then(resolver => {
         this.setState({
-          selectedResolverAddress: resolverAddress.toLowerCase(),
+          resolver: resolver,
         });
       });
     this.state = {
       resolvers: [],
       isLuminoNode: false,
-      selectedResolverAddress: '',
+      resolver: '',
     };
   }
 
   render () {
     const {domain, domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, newChainAddresses, newSubdomains, showPay } = this.props;
-    const {resolvers, isLuminoNode, selectedResolverAddress} = this.state;
+    const {resolvers, isLuminoNode, resolver} = this.state;
+    const selectedResolverAddress = resolver.address.toLowerCase();
     const domainInfo = {
       domainName,
       expirationDate,
@@ -184,6 +185,7 @@ class DomainsDetailActiveScreen extends Component {
                    domain: domain,
                    domainName: domainName,
                    selectedResolverAddress: selectedResolverAddress,
+                   isPending: resolver.pending,
                  })}
             >
               <line x1="16" y1="4.37114e-08" x2="16" y2="23" stroke="#602A95" strokeWidth="2"/>
@@ -284,7 +286,7 @@ const mapDispatchToProps = dispatch => {
     showPay: (domainInfo) => dispatch(rifActions.navigateTo(pageNames.rns.pay, {
       domainInfo: domainInfo,
     })),
-    getResolverAddress: (domainName) => dispatch(rifActions.getResolverAddress(domainName)),
+    getResolver: (domainName) => dispatch(rifActions.getResolver(domainName)),
   }
 }
 

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
@@ -34,7 +34,6 @@ class DomainsDetailConfigurationScreen extends Component {
       resolvers: [],
       configuration: null,
       disableSelect: props.disableSelect || false,
-      selectedAddress: '',
     };
   }
 
@@ -97,11 +96,12 @@ class DomainsDetailConfigurationScreen extends Component {
         <p className="resolver-setting__text">The Resolver is a Smart Contract responsible for the process of translating names into addresses. You can select a public resolver or a custom resolver.</p>
         <div id="selectResolver">
           <select id="comboResolvers"
-                  defaultValue={this.getDefaultSelectedValue(this.state.resolvers, selectedResolverAddress)}
                   onChange={this.onChangeComboResolvers.bind(this)}
                   disabled={disableSelect}
+                  value={disableSelect ? 'pending' : this.getDefaultSelectedValue(this.state.resolvers, selectedResolverAddress)}
           >
             <option disabled value={this.state.configuration.rns.contracts.publicResolver} hidden> Select Resolver </option>
+            <option disabled={!disableSelect} value={'pending'} hidden={!disableSelect}> Pending... </option>
             {
               this.state.resolvers.map((resolver, index) => {
                 return (<option


### PR DESCRIPTION
This PR adds the functionality to show a pending setting resolver address.
It also refactorizes some of the code of the pending actions in other places

![1234](https://user-images.githubusercontent.com/35036353/87834019-b4439e00-c85f-11ea-9d31-9454a2a93a71.gif)
