### PR TITLE
RIFEX-265/Clickable-channels

### DIFF
--- a/ui/app/rif/components/luminoChannelItem/index.js
+++ b/ui/app/rif/components/luminoChannelItem/index.js
@@ -9,24 +9,24 @@ class LuminoChannelItem extends Component {
     tokenSymbol: PropTypes.string.isRequired,
     balance: PropTypes.string.isRequired,
     state: PropTypes.string.isRequired,
-    onRightChevronClick: PropTypes.func,
+    onClick: PropTypes.func,
     isOpening: PropTypes.bool,
   }
 
-  onChevronClick = () => {
-    const {isOpening, onRightChevronClick} = this.props;
+  onRowClick = () => {
+    const {isOpening, onClick} = this.props;
     if (!isOpening) {
-      return onRightChevronClick()
+      return onClick()
     }
   }
 
   render = () => {
     const {partnerAddress, isOpening, balance = '0', state, tokenSymbol} = this.props;
-    return (<div className="row-data-container">
+    return (<div className="row-data-container c-pointer" onClick={this.onRowClick}>
       <span className="lumino-partner-address">{partnerAddress}</span>
       <span className="ml-auto lumino-balance mr-1">{getBalanceInEth(balance)} <small>{tokenSymbol}</small></span>
       <span className={`lumino-label-state ${state}`}>{state}</span>
-      <div className="ml-auto c-pointer" onClick={this.onChevronClick}>
+      <div className="ml-auto">
         {!isOpening && <img height={15} width={15} src="images/rif/chevronRight.svg" className="d-block"/>}
       </div>
 

--- a/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
+++ b/ui/app/rif/pages/lumino/luminoNetworkDetails/index.js
@@ -80,7 +80,7 @@ class LuminoNetworkDetails extends Component {
         content: <LuminoChannelItem key={c.channel_identifier} partnerAddress={c.partner_address}
                                     balance={c.offChainBalance} isOpening={c.isOpening}
                                     state={getStatus(c.sdk_status)} tokenSymbol={networkSymbol}
-                                    onRightChevronClick={() => this.props.showChannelDetails({
+                                    onClick={() => this.props.showChannelDetails({
                                       channel: c,
                                     })}/>,
       };


### PR DESCRIPTION
Now, the whole LuminoChannelItem can be clicked, in order to navigate to its details page