### PR TITLE
RIFEX-49/Edit-subdomains

### DIFF
--- a/app/scripts/controllers/rif/rns/resolver/index.js
+++ b/app/scripts/controllers/rif/rns/resolver/index.js
@@ -8,6 +8,7 @@ import MultiChainresolver from '../abis/MultiChainResolver.json';
 import {DOMAIN_STATUSES, EXPIRING_REMAINING_DAYS, rns} from '../../constants';
 import { getDateFormatted } from '../../utils/dateUtils';
 import {ChainId} from '@rsksmart/rns/lib/types';
+import {getNodeHash} from '../../utils/rns';
 
 /**
  * This is a delegate to manage all the RNS resolver operations.
@@ -107,12 +108,7 @@ export default class RnsResolver extends RnsJsDelegate {
    */
   getResolver (domainName, subdomain = '') {
     return new Promise((resolve, reject) => {
-      let node = namehash.hash(domainName);
-      if (subdomain) {
-        node = rskNameHash(domainName);
-        const label = web3Utils.sha3(subdomain);
-        node = web3Utils.soliditySha3(node, label);
-      }
+      const node = getNodeHash(domainName, subdomain);
       this.call(this.rnsContractInstance, 'resolver', [node]).then(result => {
         console.debug('getResolver resolved with', result);
         const domain = this.getDomain(domainName, result.address, result.network);
@@ -157,12 +153,8 @@ export default class RnsResolver extends RnsJsDelegate {
         }
         this.updateDomain(domain);
       }
-      let node = namehash.hash(domainName);
-      if (subdomain) {
-        node = rskNameHash(domainName);
-        const label = web3Utils.sha3(subdomain);
-        node = web3Utils.soliditySha3(node, label);
-      }
+      const node = getNodeHash(domainName, subdomain);
+
       const transactionListener = this.send(this.rnsContractInstance, 'setResolver', [node, resolverAddress]);
       transactionListener.transactionConfirmed()
         .then(result => {
@@ -209,12 +201,7 @@ export default class RnsResolver extends RnsJsDelegate {
    */
   getChainAddressForResolvers (domainName, subdomain = '') {
     return new Promise(async (resolve, reject) => {
-      let node = namehash.hash(domainName);
-      if (subdomain) {
-        node = rskNameHash(domainName);
-        const label = web3Utils.sha3(subdomain);
-        node = web3Utils.soliditySha3(node, label);
-      }
+      const node = getNodeHash(domainName, subdomain);
       const addrChangedEvent = await this.notifierManager.operations.getRnsEvents(this.notifierManager.apiKey, node, 'AddrChanged');
       const chainAddrChangedEvent = await this.notifierManager.operations.getRnsEvents(this.notifierManager.apiKey, node, 'ChainAddrChanged');
       const arrChains = [];
@@ -292,12 +279,7 @@ export default class RnsResolver extends RnsJsDelegate {
    */
   setChainAddressForResolver (domainName, chain, chainAddress, subdomain = '', action = 'add') {
     return new Promise((resolve, reject) => {
-      let node = namehash.hash(domainName);
-      if (subdomain) {
-        node = rskNameHash(domainName);
-        const label = web3Utils.sha3(subdomain);
-        node = web3Utils.soliditySha3(node, label);
-      }
+      const node = getNodeHash(domainName, subdomain);
       const toBeSettedChainAddress = chainAddress || rns.zeroAddress;
       const domain = this.getDomain(domainName);
       const pendingChainAddressesActions = domain.pendingActions.chainAddresses;

--- a/app/scripts/controllers/rif/rns/rnsjs-delegate.js
+++ b/app/scripts/controllers/rif/rns/rnsjs-delegate.js
@@ -336,6 +336,7 @@ export default class RnsJsDelegate extends RnsDelegate {
       ownerAddress: '',
       parentOwnerAddress: '',
       status,
+      pendingSetResolver: false,
     }
   }
 

--- a/app/scripts/controllers/rif/utils/rns.js
+++ b/app/scripts/controllers/rif/utils/rns.js
@@ -1,4 +1,6 @@
 import web3Utils from 'web3-utils';
+import * as namehash from 'eth-ens-namehash';
+import {namehash as rskNameHash} from '@rsksmart/rns/lib/utils';
 
 export function generateRandomSecret () {
   const randomBytes = window.crypto.getRandomValues(new Uint8Array(32));
@@ -36,4 +38,14 @@ export function numberToUint32 (number) {
 
 export function utf8ToHexString (string) {
   return string ? web3Utils.asciiToHex(string).slice(2) : '';
+}
+
+export function getNodeHash(domainName, subdomainName = '') {
+  let node = namehash.hash(domainName);
+  if (subdomainName) {
+    node = rskNameHash(domainName);
+    const label = web3Utils.sha3(subdomainName);
+    node = web3Utils.soliditySha3(node, label);
+  }
+  return node;
 }

--- a/ui/app/constants/common.js
+++ b/ui/app/constants/common.js
@@ -6,3 +6,5 @@ export const PRIMARY = 'PRIMARY'
 export const SECONDARY = 'SECONDARY'
 
 export const WAIT_FOR_NOTIFIER = 2000;
+
+export const WAIT_FOR_CONFIRMATION_DEFAULT = 2000;

--- a/ui/app/constants/common.js
+++ b/ui/app/constants/common.js
@@ -7,4 +7,5 @@ export const SECONDARY = 'SECONDARY'
 
 export const WAIT_FOR_NOTIFIER = 2000;
 
+// The main idea of this constant is to use it when we need something thats has a status of 'pending', and we use timeouts to get the final result
 export const WAIT_FOR_CONFIRMATION_DEFAULT = 2000;

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -191,11 +191,11 @@ function getDomainByAddress (address) {
   }
 }
 
-function setResolverAddress (domainName, resolverAddress) {
+function setResolverAddress (domainName, resolverAddress, subdomain = '') {
   return (dispatch) => {
     dispatch(niftyActions.showLoadingIndication());
     return new Promise((resolve, reject) => {
-      background.rif.rns.resolver.setResolver(domainName, resolverAddress, (error, transactionListenerId) => {
+      background.rif.rns.resolver.setResolver(domainName, resolverAddress, subdomain, (error, transactionListenerId) => {
         dispatch(niftyActions.hideLoadingIndication());
         if (error) {
           handleError(error, dispatch);
@@ -207,10 +207,10 @@ function setResolverAddress (domainName, resolverAddress) {
   }
 }
 
-function getResolver (domainName) {
+function getResolver (domainName, subdomain = '') {
   return (dispatch) => {
     return new Promise((resolve, reject) => {
-      background.rif.rns.resolver.getResolver(domainName, (error, resolver) => {
+      background.rif.rns.resolver.getResolver(domainName, subdomain, (error, resolver) => {
         if (error) {
           handleError(error, dispatch);
           return reject(error);

--- a/ui/app/rif/components/chainAddresses.js
+++ b/ui/app/rif/components/chainAddresses.js
@@ -63,16 +63,18 @@ class ChainAddresses extends Component {
     this.loadResolver();
   }
 
-  timeoutToLoadResolver = () => setTimeout(async () => {
-    let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomainName);
-    if (resolver.pending) {
-      this.timeouts.push(this.timeoutToLoadResolver());
-    } else {
-      this.setState({
-        selectedResolverAddress: resolver.address.toLowerCase(),
-      });
-    }
-  }, WAIT_FOR_CONFIRMATION_DEFAULT);
+  timeoutToLoadResolver () {
+    setTimeout(async () => {
+      let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomainName);
+      if (resolver.pending) {
+        this.timeouts.push(this.timeoutToLoadResolver());
+      } else {
+        this.setState({
+          selectedResolverAddress: resolver.address.toLowerCase(),
+        });
+      }
+    }, WAIT_FOR_CONFIRMATION_DEFAULT);
+  }
 
   loadResolver () {
     this.props.getResolver(this.props.domainName, this.props.subdomainName)
@@ -151,26 +153,28 @@ class ChainAddresses extends Component {
     this.setState({ insertedAddress: address });
   }
 
- timeoutToRedirect = (chainAddressesCopy, selectedChainAddress) => setTimeout(async () => {
-    let chainAddresses = await this.props.getChainAddresses(this.props.domainName, this.props.subdomainName);
-    // I need to compare the chainaddresses without the actions setted, cause the actions will be variant in time, but will send the chainaddresses to the component
-    const chainAddressesWithoutActions = chainAddresses.map(chainaddress => {
-      chainaddress.action = '';
-      return chainaddress;
-    });
-    console.debug('chainAddresses to compare', chainAddressesWithoutActions);
-    console.debug('This are the chainaddresses copied', chainAddressesCopy);
-    if (!arraysMatch(chainAddressesCopy, chainAddressesWithoutActions)) {
-      this.props.showThis(
-        this.props.redirectPage,
-        {
-          ...this.props.redirectParams,
-          newChainAddresses: chainAddresses,
-        });
-    } else {
-      this.timeouts.push(this.timeoutToRedirect(chainAddressesCopy, selectedChainAddress));
-    }
-  }, WAIT_FOR_NOTIFIER);
+ timeoutToRedirect(chainAddressesCopy, selectedChainAddress) {
+    setTimeout(async () => {
+     let chainAddresses = await this.props.getChainAddresses(this.props.domainName, this.props.subdomainName);
+     // I need to compare the chainaddresses without the actions setted, cause the actions will be variant in time, but will send the chainaddresses to the component
+     const chainAddressesWithoutActions = chainAddresses.map(chainaddress => {
+       chainaddress.action = '';
+       return chainaddress;
+     });
+     console.debug('chainAddresses to compare', chainAddressesWithoutActions);
+     console.debug('This are the chainaddresses copied', chainAddressesCopy);
+     if (!arraysMatch(chainAddressesCopy, chainAddressesWithoutActions)) {
+       this.props.showThis(
+         this.props.redirectPage,
+         {
+           ...this.props.redirectParams,
+           newChainAddresses: chainAddresses,
+         });
+     } else {
+       this.timeouts.push(this.timeoutToRedirect(chainAddressesCopy, selectedChainAddress));
+     }
+   }, WAIT_FOR_NOTIFIER);
+ }
 
   componentWillUnmount () {
     this.timeouts.forEach(timeout => clearTimeout(timeout));

--- a/ui/app/rif/components/chainAddresses.js
+++ b/ui/app/rif/components/chainAddresses.js
@@ -64,23 +64,23 @@ class ChainAddresses extends Component {
   }
 
   timeoutToLoadResolver () {
-    setTimeout(async () => {
+    this.timeouts.push(setTimeout(async () => {
       let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomainName);
       if (resolver.pending) {
-        this.timeouts.push(this.timeoutToLoadResolver());
+        this.timeoutToLoadResolver();
       } else {
         this.setState({
           selectedResolverAddress: resolver.address.toLowerCase(),
         });
       }
-    }, WAIT_FOR_CONFIRMATION_DEFAULT);
+    }, WAIT_FOR_CONFIRMATION_DEFAULT));
   }
 
   loadResolver () {
     this.props.getResolver(this.props.domainName, this.props.subdomainName)
       .then(resolver => {
         if (resolver.pending) {
-          this.timeouts.push(this.timeoutToLoadResolver());
+          this.timeoutToLoadResolver();
         } else {
           this.setState({
             selectedResolverAddress: resolver.address.toLowerCase(),
@@ -154,7 +154,7 @@ class ChainAddresses extends Component {
   }
 
  timeoutToRedirect(chainAddressesCopy, selectedChainAddress) {
-    setTimeout(async () => {
+   this.timeouts.push(setTimeout(async () => {
      let chainAddresses = await this.props.getChainAddresses(this.props.domainName, this.props.subdomainName);
      // I need to compare the chainaddresses without the actions setted, cause the actions will be variant in time, but will send the chainaddresses to the component
      const chainAddressesWithoutActions = chainAddresses.map(chainaddress => {
@@ -171,9 +171,9 @@ class ChainAddresses extends Component {
            newChainAddresses: chainAddresses,
          });
      } else {
-       this.timeouts.push(this.timeoutToRedirect(chainAddressesCopy, selectedChainAddress));
+       this.timeoutToRedirect(chainAddressesCopy, selectedChainAddress);
      }
-   }, WAIT_FOR_NOTIFIER);
+   }, WAIT_FOR_NOTIFIER));
  }
 
   componentWillUnmount () {
@@ -203,7 +203,7 @@ class ChainAddresses extends Component {
                   return chainAddress;
                 });
                 // This timeout is here because as we are using the notifier service, when we recieve the success, the notifier still doesnt have the last notification
-                this.timeouts.push(this.timeoutToRedirect(chainAddressesState, selectedChainAddress));
+                this.timeoutToRedirect(chainAddressesState, selectedChainAddress);
               }
             });
         },

--- a/ui/app/rif/components/chainAddresses.js
+++ b/ui/app/rif/components/chainAddresses.js
@@ -45,11 +45,13 @@ class ChainAddresses extends Component {
           resolvers,
         });
       });
-    this.props.getResolver(this.props.domainName)
+    this.props.getResolver(this.props.domainName, this.props.subdomainName)
       .then(resolver => {
-        this.setState({
-          selectedResolverAddress: resolver.address.toLowerCase(),
-        });
+        if (!resolver.pending) {
+          this.setState({
+            selectedResolverAddress: resolver.address.toLowerCase(),
+          });
+        }
       });
     const slipChainAddressesOrdered = Object.assign([], lodash.orderBy(SLIP_ADDRESSES, ['name'], ['asc']));
     const slipChainAddresses = [...PRIORITY_SLIP_ADDRESSES, ...slipChainAddressesOrdered]
@@ -268,7 +270,7 @@ function mapDispatchToProps (dispatch) {
     showTransactionConfirmPage: (callbacks) => dispatch(rifActions.goToConfirmPageForLastTransaction(callbacks)),
     getConfiguration: () => dispatch(rifActions.getConfiguration()),
     showToast: (message, success) => dispatch(niftyActions.displayToast(message, success)),
-    getResolver: (domainName) => dispatch(rifActions.getResolver(domainName)),
+    getResolver: (domainName, subdomainName) => dispatch(rifActions.getResolver(domainName, subdomainName)),
   }
 }
 module.exports = connect(mapStateToProps, mapDispatchToProps)(ChainAddresses);

--- a/ui/app/rif/components/chainAddresses.js
+++ b/ui/app/rif/components/chainAddresses.js
@@ -61,14 +61,6 @@ class ChainAddresses extends Component {
         });
       });
     this.loadResolver();
-    this.props.getResolver(this.props.domainName, this.props.subdomainName)
-      .then(resolver => {
-        if (!resolver.pending) {
-          this.setState({
-            selectedResolverAddress: resolver.address.toLowerCase(),
-          });
-        }
-      });
   }
 
   timeoutToLoadResolver = () => setTimeout(async () => {

--- a/ui/app/rif/components/subDomains.js
+++ b/ui/app/rif/components/subDomains.js
@@ -68,14 +68,14 @@ class Subdomains extends Component {
             actionClasses={classes.contentActions}
             text={subdomain.name}
             enableRightChevron={!subdomain.status}
-            onClick={() => showSubdomainDetails({
+            onClick={() => !subdomain.status ? showSubdomainDetails({
               domainName: domainInfo.domainName,
               selectedResolverAddress: domainInfo.selectedResolverAddress,
               isDomainOwner: isOwner,
               subdomain: subdomain,
               pageName: pageName,
               redirectParams: redirectParams,
-            })}
+            }) : {}}
             showPending={subdomain.status}
           />
         )

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
@@ -111,7 +111,6 @@ class DomainsDetailActiveScreen extends Component {
     expirationDate: PropTypes.string.isRequired,
     autoRenew: PropTypes.bool.isRequired,
     ownerAddress: PropTypes.string.isRequired,
-    selectedResolverAddress: PropTypes.string,
     isOwner: PropTypes.bool,
     isRifStorage: PropTypes.bool,
     displayToast: PropTypes.func.isRequired,
@@ -150,14 +149,14 @@ class DomainsDetailActiveScreen extends Component {
     this.state = {
       resolvers: [],
       isLuminoNode: false,
-      resolver: '',
+      resolver: {},
     };
   }
 
   render () {
     const {domain, domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, newChainAddresses, newSubdomains, showPay } = this.props;
     const {resolvers, isLuminoNode, resolver} = this.state;
-    const selectedResolverAddress = resolver ? resolver.address.toLowerCase() : '';
+    const selectedResolverAddress = (resolver && resolver.address) ? resolver.address.toLowerCase() : '';
     const domainInfo = {
       domainName,
       expirationDate,
@@ -183,9 +182,6 @@ class DomainsDetailActiveScreen extends Component {
                  className="config-domain-btn"
                  onClick={() => this.props.showConfigPage({
                    domain: domain,
-                   domainName: domainName,
-                   selectedResolverAddress: selectedResolverAddress,
-                   disableSelect: resolver.pending,
                  })}
             >
               <line x1="16" y1="4.37114e-08" x2="16" y2="23" stroke="#602A95" strokeWidth="2"/>

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
@@ -154,7 +154,7 @@ class DomainsDetailActiveScreen extends Component {
   }
 
   render () {
-    const {domain, domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, newChainAddresses, newSubdomains, showPay } = this.props;
+    const { domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, newChainAddresses, newSubdomains, showPay } = this.props;
     const {resolvers, isLuminoNode, resolver} = this.state;
     const selectedResolverAddress = (resolver && resolver.address) ? resolver.address.toLowerCase() : '';
     const domainInfo = {
@@ -181,7 +181,7 @@ class DomainsDetailActiveScreen extends Component {
             <svg width="19" height="23" viewBox="0 0 19 23" fill="none" xmlns="http://www.w3.org/2000/svg"
                  className="config-domain-btn"
                  onClick={() => this.props.showConfigPage({
-                   domain: domain,
+                   domainName: domainName,
                  })}
             >
               <line x1="16" y1="4.37114e-08" x2="16" y2="23" stroke="#602A95" strokeWidth="2"/>

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
@@ -58,17 +58,19 @@ class DomainsDetailConfigurationScreen extends Component {
     }
   }
 
-  timeoutToLoadResolver = () => setTimeout(async () => {
-    let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomainName);
-    if (resolver.pending) {
-      this.timeouts.push(this.timeoutToLoadResolver());
-    } else {
-      this.setState({
-        resolver: resolver,
-        disableSelect: resolver.pending,
-      });
-    }
-  }, WAIT_FOR_CONFIRMATION_DEFAULT);
+  timeoutToLoadResolver() {
+    setTimeout(async () => {
+      let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomainName);
+      if (resolver.pending) {
+        this.timeouts.push(this.timeoutToLoadResolver());
+      } else {
+        this.setState({
+          resolver: resolver,
+          disableSelect: resolver.pending,
+        });
+      }
+    }, WAIT_FOR_CONFIRMATION_DEFAULT);
+  }
 
   componentWillUnmount () {
     this.timeouts.forEach(timeout => clearTimeout(timeout));

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
@@ -110,7 +110,7 @@ class DomainsDetailConfigurationScreen extends Component {
                         address: address,
                       },
                     });
-                  }, 2000);
+                  }, WAIT_FOR_CONFIRMATION_DEFAULT);
                 });
             },
           },

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
@@ -36,7 +36,6 @@ class DomainsDetailConfigurationScreen extends Component {
       configuration: null,
       resolver: {},
       disableSelect: true,
-      reloadResolver: false,
     };
   }
 
@@ -77,10 +76,14 @@ class DomainsDetailConfigurationScreen extends Component {
   loadResolver () {
     this.props.getResolver(this.props.domainName)
       .then(resolver => {
-        this.setState({
-          resolver: resolver,
-          disableSelect: resolver.pending,
-        });
+        if (resolver.pending) {
+          this.timeouts.push(this.timeoutToLoadResolver());
+        } else {
+          this.setState({
+            resolver: resolver,
+            disableSelect: resolver.pending,
+          });
+        }
       });
   }
 

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActiveConfig/index.js
@@ -59,17 +59,17 @@ class DomainsDetailConfigurationScreen extends Component {
   }
 
   timeoutToLoadResolver() {
-    setTimeout(async () => {
+    this.timeouts.push(setTimeout(async () => {
       let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomainName);
       if (resolver.pending) {
-        this.timeouts.push(this.timeoutToLoadResolver());
+        this.timeoutToLoadResolver();
       } else {
         this.setState({
           resolver: resolver,
           disableSelect: resolver.pending,
         });
       }
-    }, WAIT_FOR_CONFIRMATION_DEFAULT);
+    }, WAIT_FOR_CONFIRMATION_DEFAULT));
   }
 
   componentWillUnmount () {
@@ -80,7 +80,7 @@ class DomainsDetailConfigurationScreen extends Component {
     this.props.getResolver(this.props.domainName, this.props.subdomainName)
       .then(resolver => {
         if (resolver.pending) {
-          this.timeouts.push(this.timeoutToLoadResolver());
+          this.timeoutToLoadResolver();
         } else {
           this.setState({
             resolver: resolver,
@@ -104,7 +104,7 @@ class DomainsDetailConfigurationScreen extends Component {
               this.props.showToast('Waiting Confirmation');
               this.props.waitForListener(transactionListenerId)
                 .then(transactionReceipt => {
-                  setTimeout(() => {
+                  this.timeouts.push(setTimeout(() => {
                     this.props.showDomainConfigPage({
                       ...this.props,
                       resolver: {
@@ -112,7 +112,7 @@ class DomainsDetailConfigurationScreen extends Component {
                         address: address,
                       },
                     });
-                  }, WAIT_FOR_CONFIRMATION_DEFAULT);
+                  }, WAIT_FOR_CONFIRMATION_DEFAULT));
                 });
             },
           },

--- a/ui/app/rif/pages/rns/subdomains/index.js
+++ b/ui/app/rif/pages/rns/subdomains/index.js
@@ -114,16 +114,16 @@ class Subdomains extends Component {
   }
 
   timeoutToLoadResolver() {
-    setTimeout(async () => {
+    this.timeouts.push(setTimeout(async () => {
       let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomain.name);
       if (resolver.pending) {
-        this.timeouts.push(this.timeoutToLoadResolver());
+        this.timeoutToLoadResolver();
       } else {
         this.setState({
           resolver: resolver,
         });
       }
-    }, WAIT_FOR_CONFIRMATION_DEFAULT);
+    }, WAIT_FOR_CONFIRMATION_DEFAULT));
   }
 
   componentWillUnmount () {
@@ -134,7 +134,7 @@ class Subdomains extends Component {
     this.props.getResolver(this.props.domainName, this.props.subdomain.name)
       .then(resolver => {
         if (resolver.pending) {
-          this.timeouts.push(this.timeoutToLoadResolver());
+          this.timeoutToLoadResolver();
         } else {
           this.setState({
             resolver: resolver,

--- a/ui/app/rif/pages/rns/subdomains/index.js
+++ b/ui/app/rif/pages/rns/subdomains/index.js
@@ -113,16 +113,18 @@ class Subdomains extends Component {
     this.loadResolver();
   }
 
-  timeoutToLoadResolver = () => setTimeout(async () => {
-    let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomain.name);
-    if (resolver.pending) {
-      this.timeouts.push(this.timeoutToLoadResolver());
-    } else {
-      this.setState({
-        resolver: resolver,
-      });
-    }
-  }, WAIT_FOR_CONFIRMATION_DEFAULT);
+  timeoutToLoadResolver() {
+    setTimeout(async () => {
+      let resolver = await this.props.getResolver(this.props.domainName, this.props.subdomain.name);
+      if (resolver.pending) {
+        this.timeouts.push(this.timeoutToLoadResolver());
+      } else {
+        this.setState({
+          resolver: resolver,
+        });
+      }
+    }, WAIT_FOR_CONFIRMATION_DEFAULT);
+  }
 
   componentWillUnmount () {
     this.timeouts.forEach(timeout => clearTimeout(timeout));

--- a/ui/app/rif/pages/rns/subdomains/index.js
+++ b/ui/app/rif/pages/rns/subdomains/index.js
@@ -88,6 +88,7 @@ class Subdomains extends Component {
     getSubdomains: PropTypes.func,
     getConfiguration: PropTypes.func,
     isDomainOwner: PropTypes.bool,
+    showConfigPage: PropTypes.func,
   }
 
   constructor (props) {
@@ -165,13 +166,27 @@ class Subdomains extends Component {
             }
           />
           }
+          {isOwner &&
+            <svg width="19" height="23" viewBox="0 0 19 23" fill="none" xmlns="http://www.w3.org/2000/svg"
+                 className="config-domain-btn"
+                 onClick={() => this.props.showConfigPage({
+                   domainName: domainName,
+                 })}
+            >
+              <line x1="16" y1="4.37114e-08" x2="16" y2="23" stroke="#602A95" strokeWidth="2"/>
+              <line x1="9" y1="4.37114e-08" x2="9" y2="23" stroke="#602A95" strokeWidth="2"/>
+              <line x1="3" y1="4.37114e-08" x2="3" y2="23" stroke="#602A95" strokeWidth="2"/>
+              <ellipse cx="9" cy="17" rx="3" ry="3" transform="rotate(90 9 17)" fill="#602A95"/>
+              <ellipse cx="16" cy="5" rx="3" ry="3" transform="rotate(90 16 5)" fill="#602A95"/>
+              <ellipse cx="3" cy="8" rx="3" ry="3" transform="rotate(90 3 8)" fill="#602A95"/>
+            </svg>
+          }
         </DomainHeader>
         {resolvers &&
         <div id="chainAddressesBody">
           <ChainAddresses
             domainName={domainName}
             subdomainName={subdomain.name}
-            selectedResolverAddress={selectedResolverAddress}
             paginationSize={PAGINATION_DEFAULT_SIZE}
             classes={styles.chainAddresses}
             isOwner={isOwner}
@@ -220,6 +235,13 @@ function mapDispatchToProps (dispatch) {
     isSubdomainAvailable: (domainName, subdomain) => dispatch(rifActions.isSubdomainAvailable(domainName, subdomain)),
     deleteSubdomain: (domainName, subdomain) => dispatch(rifActions.deleteSubdomain(domainName, subdomain)),
     getConfiguration: () => dispatch(rifActions.getConfiguration()),
+    showConfigPage: (props) => dispatch(rifActions.navigateTo(pageNames.rns.domainsDetailConfiguration, {
+      ...props,
+      tabOptions: {
+        showSearchbar: false,
+        showBack: true,
+      },
+    })),
   }
 }
 

--- a/ui/app/rif/pages/rns/subdomains/index.js
+++ b/ui/app/rif/pages/rns/subdomains/index.js
@@ -120,7 +120,6 @@ class Subdomains extends Component {
     } else {
       this.setState({
         resolver: resolver,
-        disableSelect: resolver.pending,
       });
     }
   }, WAIT_FOR_CONFIRMATION_DEFAULT);


### PR DESCRIPTION
This PR adds the functionality to the subdomains, so you can set a resolver for each
-Refactor of domainConfig, so we can use it in domain and subdomains
-Timeout added to config, for resolver pending
-Timeout added to chainaddresses component, to retry and get the resolver (When status is pending)
-Refactor of background so we can set the resolver in subdomains

![SubdomainConfigResolverResized](https://user-images.githubusercontent.com/35036353/88104297-a00de280-cb78-11ea-9f67-58344ff80a6b.gif)
