### PR TITLE
Rifex 261/clear search bar

### DIFF
--- a/ui/app/rif/components/genericSearch/index.js
+++ b/ui/app/rif/components/genericSearch/index.js
@@ -47,9 +47,8 @@ class GenericSearch extends Component {
     const {onlyFilterOnEnter} = this.props;
     const enterPressed = e.key === 'Enter';
 
-    if (!onlyFilterOnEnter && !enterPressed) {    debugger;
-
-      this.filter(value)
+    if (!onlyFilterOnEnter && !enterPressed) {
+      this.filter(value);
     }
   }
 

--- a/ui/app/rif/components/genericSearch/index.js
+++ b/ui/app/rif/components/genericSearch/index.js
@@ -38,7 +38,6 @@ class GenericSearch extends Component {
 
   clear = () => {
     this.setState({value: ''})
-    console.error('limpio');
   }
 
   handleOnChange = (e) => {

--- a/ui/app/rif/components/genericSearch/index.js
+++ b/ui/app/rif/components/genericSearch/index.js
@@ -89,8 +89,8 @@ class GenericSearch extends Component {
         <input
           placeholder={placeholder || ''}
           className={'search-bar'}
-          onChange={() => this.handleOnChange}
-          onKeyDown={() => this.handleOnKeyDown}
+          onChange={(e) => this.handleOnChange(e)}
+          onKeyDown={(e) => this.handleOnKeyDown(e)}
           value={value}
         />
       </div>

--- a/ui/app/rif/components/genericSearch/index.js
+++ b/ui/app/rif/components/genericSearch/index.js
@@ -20,6 +20,15 @@ class GenericSearch extends Component {
     onlyFilterOnEnter: PropTypes.bool,
   }
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: ''
+    }
+    this.handleOnChange = this.handleOnChange.bind(this)
+    this.handleOnKeyDown = this.handleOnKeyDown.bind(this)
+  }
+
   includesCriteria = (element, criteria) => {
     const lowerString = v => String(v).toLowerCase()
     const lowerElement = lowerString(element);
@@ -27,12 +36,34 @@ class GenericSearch extends Component {
     return lowerElement.includes(lowerCriteria);
   }
 
-  handleInput = async (e) => {
+  clear = () => {
+    this.setState({value: ''})
+    console.error('limpio');
+  }
+
+  handleOnChange = (e) => {
+    const {value} = e.target;
+    this.setState({value})
     const {onlyFilterOnEnter} = this.props;
     const enterPressed = e.key === 'Enter';
-    const shouldFilter = (!onlyFilterOnEnter && !enterPressed) || (onlyFilterOnEnter && enterPressed)
-    if (shouldFilter) {
-      const {value} = e.target;
+
+    if (!onlyFilterOnEnter && !enterPressed) {    debugger;
+
+      this.filter(value)
+    }
+  }
+
+  handleOnKeyDown = async (e) => {
+    const {value} = e.target;
+    const {onlyFilterOnEnter} = this.props;
+    const enterPressed = e.key === 'Enter';
+    if (onlyFilterOnEnter && enterPressed) {
+      await this.filter(value);
+      this.clear();
+    }
+  }
+
+  filter = async (value) => {
       const {customFilterFunction, resultSetFunction} = this.props;
 
       if (customFilterFunction) {
@@ -52,20 +83,19 @@ class GenericSearch extends Component {
       // Filter of 1st level, with the property to check
       const result = data.filter(element => this.includesCriteria(element[filterProperty], value));
       return resultSetFunction(result);
-    }
   }
 
   render () {
     const {placeholder, onlyFilterOnEnter} = this.props;
-    const handleKeydown = onlyFilterOnEnter ? this.handleInput : null;
-    const handleOnChange = onlyFilterOnEnter ? null : this.handleInput;
+    const { value } = this.state;
     return (
       <div className="search-bar-container">
         <input
           placeholder={placeholder || ''}
           className={'search-bar'}
-          onChange={handleOnChange}
-          onKeyDown={handleKeydown}
+          onChange={this.handleOnChange}
+          onKeyDown={this.handleOnKeyDown}
+          value={value}
         />
       </div>
     )

--- a/ui/app/rif/components/genericSearch/index.js
+++ b/ui/app/rif/components/genericSearch/index.js
@@ -25,22 +25,20 @@ class GenericSearch extends Component {
     this.state = {
       value: ''
     }
-    this.handleOnChange = this.handleOnChange.bind(this)
-    this.handleOnKeyDown = this.handleOnKeyDown.bind(this)
   }
 
-  includesCriteria = (element, criteria) => {
+  includesCriteria(element, criteria) {
     const lowerString = v => String(v).toLowerCase()
     const lowerElement = lowerString(element);
     const lowerCriteria = lowerString(criteria);
     return lowerElement.includes(lowerCriteria);
   }
 
-  clear = () => {
+  clear() {
     this.setState({value: ''})
   }
 
-  handleOnChange = (e) => {
+  handleOnChange(e) {
     const {value} = e.target;
     this.setState({value})
     const {onlyFilterOnEnter} = this.props;
@@ -51,7 +49,7 @@ class GenericSearch extends Component {
     }
   }
 
-  handleOnKeyDown = async (e) => {
+  async handleOnKeyDown(e) {
     const {value} = e.target;
     const {onlyFilterOnEnter} = this.props;
     const enterPressed = e.key === 'Enter';
@@ -61,7 +59,7 @@ class GenericSearch extends Component {
     }
   }
 
-  filter = async (value) => {
+  async filter(value) {
       const {customFilterFunction, resultSetFunction} = this.props;
 
       if (customFilterFunction) {
@@ -91,8 +89,8 @@ class GenericSearch extends Component {
         <input
           placeholder={placeholder || ''}
           className={'search-bar'}
-          onChange={this.handleOnChange}
-          onKeyDown={this.handleOnKeyDown}
+          onChange={() => this.handleOnChange}
+          onKeyDown={() => this.handleOnKeyDown}
           value={value}
         />
       </div>

--- a/ui/app/rif/components/searchDomains.js
+++ b/ui/app/rif/components/searchDomains.js
@@ -96,7 +96,14 @@ SearchDomains.propTypes = {
 
 const mapDispatchToProps = dispatch => {
   return {
-    showDomainsDetailPage: (data) => dispatch(rifActions.navigateTo(pageNames.rns.domainsDetail, data)),
+    showDomainsDetailPage: (data) => dispatch(rifActions.navigateTo(pageNames.rns.domainsDetail, {
+      ...data,
+      tabOptions: {
+        showSearchbar: false,
+        showBack: true,
+        tabIndex: 0,
+      },
+    })),
     showDomainRegisterPage: (domainName) => dispatch(rifActions.navigateTo(pageNames.rns.domainRegister, {
       domainName,
     })),


### PR DESCRIPTION
Clear search bar when searching for a domain
- Search bar is cleared after searching for a domain that doesn't exist.
-  Search bar is not shown in domain detail page.


Note: A minor refactor was done in genericSearch, in order to handle the search text as a state property, and clear it when needed.