### PR TITLE
RIFEX-275/Searchbar-delete-placeholder

### DIFF
--- a/ui/app/rif/components/subDomains.js
+++ b/ui/app/rif/components/subDomains.js
@@ -98,7 +98,6 @@ class Subdomains extends Component {
     return (
       <div className="subdomain-section">
         <GenericSearch
-          placeholder={'Subdomains'}
           data={subdomains}
           resultSetFunction={this.setFilteredSubdomains}
           filterProperty={'name'}/>


### PR DESCRIPTION
This PR deletes the placeholder of the searchbar located in subdomain list component. 
![image](https://user-images.githubusercontent.com/35036353/88224287-21c84380-cc3f-11ea-9afd-be75dd44d22b.png)
