### PR TITLE
RIFEX-267 fixing registration without rif tokens

### DIFF
--- a/app/scripts/controllers/rif/rns/register/index.js
+++ b/app/scripts/controllers/rif/rns/register/index.js
@@ -158,26 +158,32 @@ export default class RnsRegister extends RnsJsDelegate {
             const registerInformation = pendingDomain.registration;
             if (registerInformation) {
               const rifCost = registerInformation.rifCost;
-              const secret = registerInformation.secret;
-              const durationBN = this.web3.toBigNumber(registerInformation.yearsToRegister);
-              const data = this.getAddrRegisterData(cleanDomainName, this.address, secret, durationBN, this.address);
-              const transactionListener = this.send(this.rifContractInstance, 'transferAndCall', [this.fifsAddrRegistrarAddress, rifCost, data]);
-              pendingDomain.registration.status = 'finishing';
-              transactionListener.transactionConfirmed()
-                .then(result => {
-                  console.debug('Transaction success', result);
-                  pendingDomain.registration.status = 'finished';
-                  this.container.resolver.getDomainDetails(domainName).then(domainDetails => {
-                    pendingDomain.details = domainDetails;
-                    pendingDomain.status = 'active';
+              this.getRIFBalanceForAddress().then(balance => {
+                if (balance > parseFloat(rifCost)) {
+                  const secret = registerInformation.secret;
+                  const durationBN = this.web3.toBigNumber(registerInformation.yearsToRegister);
+                  const data = this.getAddrRegisterData(cleanDomainName, this.address, secret, durationBN, this.address);
+                  const transactionListener = this.send(this.rifContractInstance, 'transferAndCall', [this.fifsAddrRegistrarAddress, rifCost, data]);
+                  pendingDomain.registration.status = 'finishing';
+                  transactionListener.transactionConfirmed()
+                    .then(result => {
+                      console.debug('Transaction success', result);
+                      pendingDomain.registration.status = 'finished';
+                      this.container.resolver.getDomainDetails(domainName).then(domainDetails => {
+                        pendingDomain.details = domainDetails;
+                        pendingDomain.status = 'active';
+                        this.updateDomain(pendingDomain, result.address, result.network);
+                      });
+                    }).catch(result => {
+                    console.debug('Transaction failed', result);
+                    pendingDomain.registration.status = 'pending';
                     this.updateDomain(pendingDomain, result.address, result.network);
                   });
-                }).catch(result => {
-                console.debug('Transaction failed', result);
-                pendingDomain.registration.status = 'pending';
-                this.updateDomain(pendingDomain, result.address, result.network);
+                  resolve(transactionListener.id);
+                } else {
+                  reject('Insufficient RIF tokens to finish this registration, you need to buy RIF tokens first.');
+                }
               });
-              return resolve(transactionListener.id);
             } else {
               return reject('Invalid domainName, you need to use the same as the first request');
             }

--- a/app/scripts/controllers/rif/rns/rns-delegate.js
+++ b/app/scripts/controllers/rif/rns/rns-delegate.js
@@ -254,4 +254,14 @@ export default class RnsDelegate {
    * This event is to track when the user changes the rif configuration
    */
   onConfigurationUpdated (configuration) {}
+
+  getRIFBalanceForAddress (accountAddress = this.address) {
+    return new Promise((resolve, reject) => {
+      this.call(this.rifContractInstance, 'balanceOf', [accountAddress])
+        .then(balance => {
+          resolve(balance.toNumber());
+        }).catch(error => reject(error));
+    });
+  }
+
 }

--- a/app/scripts/controllers/rif/transaction-listener.js
+++ b/app/scripts/controllers/rif/transaction-listener.js
@@ -99,11 +99,21 @@ export class TransactionListener extends EventEmitter {
       this.on('submitError', (error) => {
         this.currentListeners--;
         this.shouldClean();
-        reject({
-          address: this.address,
-          network: this.network,
-          error,
-        });
+        if (error && error.message && error.message.indexOf('User denied transaction signature') !== -1) {
+          // the user rejected the operation
+          reject({
+            address: this.address,
+            network: this.network,
+            error,
+            rejectedOperation: true,
+          });
+        } else {
+          reject({
+            address: this.address,
+            network: this.network,
+            error,
+          });
+        }
       });
     });
   }

--- a/old-ui/app/account-detail.js
+++ b/old-ui/app/account-detail.js
@@ -4,7 +4,6 @@ const Component = require('react').Component
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
 const actions = require('../../ui/app/actions')
-const rifActions = require('../../ui/app/rif/actions')
 const { getCurrentKeyring, ifContractAcc, valuesFor, toChecksumAddress } = require('./util')
 const Identicon = require('./components/identicon')
 const EthBalance = require('./components/eth-balance')

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -299,11 +299,12 @@ function canFinishRegistration (commitmentHash) {
 function finishRegistration (domainName) {
   return (dispatch) => {
     dispatch(niftyActions.showLoadingIndication())
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       dispatch(niftyActions.hideLoadingIndication());
       background.rif.rns.register.finishRegistration(domainName, (error, transactionListenerId) => {
         if (error) {
           handleError(error, dispatch);
+          return reject(error);
         }
         return resolve(transactionListenerId);
       });

--- a/ui/app/rif/pages/abstract-page.js
+++ b/ui/app/rif/pages/abstract-page.js
@@ -1,0 +1,26 @@
+import React, {Component} from 'react';
+
+export class AbstractPage extends Component {
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      loading: false,
+    };
+  }
+
+  renderPage () {}
+
+  setLoading (loading) {
+    this.setState({loading});
+  }
+
+  render () {
+    const loading = this.state.loading;
+    if (loading) {
+      return (<div className="app-loader"/>)
+    } else {
+      return this.renderPage();
+    }
+  }
+}

--- a/ui/app/rif/pages/abstract-page.js
+++ b/ui/app/rif/pages/abstract-page.js
@@ -1,11 +1,18 @@
-import React, {Component} from 'react';
+import {Component} from 'react';
+import PropTypes from 'prop-types';
+import {getLoader} from '../utils/components';
 
 export class AbstractPage extends Component {
+
+  static propTypes = {
+    t: PropTypes.func,
+  }
 
   constructor (props) {
     super(props);
     this.state = {
       loading: false,
+      loadingMessage: props.t ? props.t('Wait please...') : 'Wait please...',
     };
   }
 
@@ -18,7 +25,7 @@ export class AbstractPage extends Component {
   render () {
     const loading = this.state.loading;
     if (loading) {
-      return (<div className="app-loader"/>)
+      return getLoader(this.state.loadingMessage);
     } else {
       return this.renderPage();
     }

--- a/ui/app/rif/pages/rns/register/index.js
+++ b/ui/app/rif/pages/rns/register/index.js
@@ -6,8 +6,9 @@ import niftyActions from '../../../../actions';
 import {registrationTimeouts} from '../../../constants';
 import {pageNames} from '../../index';
 import extend from 'xtend';
+import {AbstractPage} from '../../abstract-page';
 
-class DomainRegisterScreen extends Component {
+class DomainRegisterScreen extends AbstractPage {
 
   static propTypes = {
     domainName: PropTypes.string,
@@ -116,34 +117,48 @@ class DomainRegisterScreen extends Component {
     });
   }
 
-  async requestDomain () {
-    const {transactionListenerId} = await this.props.requestRegistration(this.props.domainName, this.props.yearsToRegister);
-    this.props.showTransactionConfirmPage({
-      afterApproval: {
-        action: () => {
-          this.showWaitingForConfirmation()
-          this.props.waitForListener(transactionListenerId)
-            .then(transactionReceipt => {
-              this.showWaitingForRegister();
-            });
-        },
-      },
+  requestDomain () {
+    super.setLoading(true);
+    this.props.requestRegistration(this.props.domainName, this.props.yearsToRegister)
+      .then(result => {
+        const transactionListenerId = result.transactionListenerId;
+        this.props.showTransactionConfirmPage({
+          afterApproval: {
+            action: () => {
+              this.showWaitingForConfirmation()
+              this.props.waitForListener(transactionListenerId)
+                .then(transactionReceipt => {
+                  this.showWaitingForRegister();
+                });
+            },
+          },
+        });
+      }).catch(error => {
+        console.error(error);
+        this.setLoading(false);
     });
   }
 
-  async completeRegistration () {
-    const transactionListenerId = await this.props.completeRegistration(this.props.domainName);
-    this.props.showTransactionConfirmPage({
-      afterApproval: {
-        action: () => {
-          this.afterRegistrationSubmit()
-          this.props.waitForListener(transactionListenerId)
-            .then(transactionReceipt => {
-              this.afterRegistration();
-            });
-        },
-      },
+  completeRegistration () {
+    super.setLoading(true);
+    this.props.completeRegistration(this.props.domainName)
+      .then(transactionListenerId => {
+        this.props.showTransactionConfirmPage({
+          afterApproval: {
+            action: () => {
+              this.afterRegistrationSubmit()
+              this.props.waitForListener(transactionListenerId)
+                .then(transactionReceipt => {
+                  this.afterRegistration();
+                });
+            },
+          },
+        });
+      }).catch(error => {
+        console.error(error);
+        super.setLoading(false);
     });
+
   }
 
   async afterRegistration () {
@@ -305,7 +320,7 @@ class DomainRegisterScreen extends Component {
     return partials[currentStep];
   }
 
-  render () {
+  renderPage () {
     const currentStep = this.props.currentStep ? this.props.currentStep : 'setupRegister';
     const title = this.getTitle(currentStep);
     const body = this.getBody(currentStep);


### PR DESCRIPTION
In this PR we are:

* Adding control for rif token balance
* Adding message to finish registration
* Adding method to query balance on rns delegate
* Adding new abstract page class to control the loading
* Adding logic to control the rejection
* Adding logic to control the rif balance
* Using the proper loader
* Adding future support for multi language to abstract page

Here we have a demo:

![demo](https://user-images.githubusercontent.com/7540348/88316172-c3a66980-cced-11ea-8d16-d06194b70f30.gif)

* This affects the ui and service layers