### PR TITLE
RIFEX-286/Search-domain-onregister

### DIFF
--- a/ui/app/rif/pages/rns/register/index.js
+++ b/ui/app/rif/pages/rns/register/index.js
@@ -46,6 +46,15 @@ class DomainRegisterScreen extends Component {
     });
   }
 
+  componentDidUpdate (prevProps, prevState, snapshot) {
+    if (prevProps.domainName !== this.props.domainName) {
+      this.props.showLoading();
+      this.initialize().then(() => {
+        this.props.showLoading(false);
+      });
+    }
+  }
+
   componentWillUnmount () {
     this.timeouts.forEach(timeout => clearTimeout(timeout));
   }


### PR DESCRIPTION
This PR fixes that when you're registering a domain (In register page), and you search another domain to register, it won trigger the cost of that new domain.

![SearchDomainOnregisterResized](https://user-images.githubusercontent.com/35036353/88396273-af6b7680-cd98-11ea-8ff5-8e3ab7b936bf.gif)
