### PR TITLE
RIFEX-276/Navigation-after-register

### DIFF
--- a/ui/app/rif/pages/rns/register/index.js
+++ b/ui/app/rif/pages/rns/register/index.js
@@ -368,9 +368,9 @@ const mapDispatchToProps = dispatch => {
         showBack: true,
         showTitle: true,
         screenTitle: 'My Domains',
+        },
       },
-      resetNavigation: true,
-    })),
+      true)),
     showLoading: (loading = true, message) => loading ? dispatch(niftyActions.showLoadingIndication(message)) : dispatch(niftyActions.hideLoadingIndication()),
   }
 }


### PR DESCRIPTION
This PR fixes, after you register a domain, and you try to navigate back, it will redirect you to the previous register page. 

![BackRegisterDomainResized](https://user-images.githubusercontent.com/35036353/88336618-b304ec00-cd0b-11ea-8274-c4ba476515e7.gif)
