### PR TITLE
RIFEX-289 Fixing reject all

### DIFF
--- a/old-ui/app/conf-tx.js
+++ b/old-ui/app/conf-tx.js
@@ -26,7 +26,7 @@ function mapStateToProps (state) {
     accounts: getMetaMaskAccounts(state),
     keyrings: metamask.keyrings,
     selectedAddress: metamask.selectedAddress,
-    unapprovedTxs: screenParams.unapprovedTransactions ? screenParams.unapprovedTransactions : metamask.unapprovedTxs,
+    unapprovedTxs: (screenParams && screenParams.unapprovedTransactions) ? screenParams.unapprovedTransactions : metamask.unapprovedTxs,
     unapprovedMsgs: metamask.unapprovedMsgs,
     unapprovedPersonalMsgs: metamask.unapprovedPersonalMsgs,
     unapprovedTypedMessages: metamask.unapprovedTypedMessages,
@@ -43,7 +43,7 @@ function mapStateToProps (state) {
     tokensToSend: (screenParams && screenParams.tokensToSend),
     tokensTransferTo: (screenParams && screenParams.tokensTransferTo),
     isContractExecutionByUser: (screenParams && screenParams.isContractExecutionByUser),
-    callbacks: screenParams.callbacks,
+    callbacks: (screenParams && screenParams.callbacks),
   }
 }
 


### PR DESCRIPTION
This PR fixes the reject all operation on the nifty confirmation page, here we have a demo:

![demo](https://user-images.githubusercontent.com/7540348/88410778-31fe3100-cdad-11ea-861b-597e8eb00a5b.gif)
