### PR TITLE
RIFEX-293/EditAdd-chainaddress-same-value

### DIFF
--- a/ui/app/rif/components/chainAddresses.js
+++ b/ui/app/rif/components/chainAddresses.js
@@ -185,10 +185,10 @@ class ChainAddresses extends Component {
     const selectedChainAddress = chainAddress || this.state.selectedChainAddress;
     // Before sending the new chainaddress to be added/updated, we need to check if the user is not trying to set something that already has
     if (action === 'add' && this.state.chainAddresses.find(chAddress => chAddress.chain === selectedChainAddress)) {
-      this.props.showToast('Can\'t add an address that\'s already setted. Try updating it from the list', false);
+      this.props.showToast('Address is already present. Try updating it from the list or add a new one', false);
       return;
     } else if (action === 'update' && this.state.chainAddresses.find(chAddress => chAddress.chain === selectedChainAddress && chAddress.address === insertedAddress)) {
-      this.props.showToast('Can\'t try to update an address that\'s already setted', false);
+      this.props.showToast('The address already has the same value', false);
       return;
     }
     const transactionListenerId = await this.props.setChainAddressForResolver(this.props.domainName, selectedChainAddress, insertedAddress, this.props.subdomainName, action);

--- a/ui/app/rif/components/chainAddresses.js
+++ b/ui/app/rif/components/chainAddresses.js
@@ -183,6 +183,14 @@ class ChainAddresses extends Component {
   async addAddress (address = null, chainAddress = null, toastMessage = 'Adding chain address', action = 'add') {
     const insertedAddress = address || this.state.insertedAddress;
     const selectedChainAddress = chainAddress || this.state.selectedChainAddress;
+    // Before sending the new chainaddress to be added/updated, we need to check if the user is not trying to set something that already has
+    if (action === 'add' && this.state.chainAddresses.find(chAddress => chAddress.chain === selectedChainAddress)) {
+      this.props.showToast('Can\'t add an address that\'s already setted. Try updating it from the list', false);
+      return;
+    } else if (action === 'update' && this.state.chainAddresses.find(chAddress => chAddress.chain === selectedChainAddress && chAddress.address === insertedAddress)) {
+      this.props.showToast('Can\'t try to update an address that\'s already setted', false);
+      return;
+    }
     const transactionListenerId = await this.props.setChainAddressForResolver(this.props.domainName, selectedChainAddress, insertedAddress, this.props.subdomainName, action);
     this.props.showTransactionConfirmPage({
       afterApproval: {


### PR DESCRIPTION
This PR fixes that when you try to add a chain address that's already added, it shows a toast message that it cant add it
Also fixes that when you try to update a chain address with the same value that it has

![ChainAddressalreadyaddedResized](https://user-images.githubusercontent.com/35036353/88547690-72032500-cff4-11ea-8ab5-33a4c813c39c.gif)


