### PR TITLE
fix/RIFEX-299/network-after-delete

### DIFF
--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -2766,7 +2766,7 @@ function removeCustomRPC (url, provider) {
     return new Promise((resolve, reject) => {
       background.removeRpcUrl(url, (err, _url) => {
         if (provider.type === 'rpc' && url === provider.rpcTarget) {
-          dispatch(actions.setProviderType('poa'))
+          dispatch(actions.setProviderType(RSK))
         }
         dispatch(actions.hideLoadingIndication())
         if (err) {


### PR DESCRIPTION
Changes:
-  RSK MAINNET as selected network after removing custom network
