### PR TITLE
Feature/rifex 315 316/modifying home and blocking lumino for hardware

### DIFF
--- a/app/scripts/controllers/rif/index.js
+++ b/app/scripts/controllers/rif/index.js
@@ -226,14 +226,19 @@ export default class RifController {
 
   setUsingHardwareWallet (using = true) {
     const state = this.store.getState();
-    state.usingHardwareWallet = using;
+    state[this.address] = {
+      usingHardwareWallet: using,
+    };
     this.store.updateState(state);
     return Promise.resolve();
   }
 
   isUsingHardwareWallet () {
     const state = this.store.getState();
-    return Promise.resolve(state.usingHardwareWallet);
+    if (state[this.address]) {
+      return Promise.resolve(state[this.address].usingHardwareWallet);
+    }
+    return Promise.resolve(false);
   }
 
   /**

--- a/app/scripts/controllers/rif/index.js
+++ b/app/scripts/controllers/rif/index.js
@@ -28,7 +28,7 @@ export default class RifController {
     this.metamaskController = props.metamaskController;
     this.web3 = new Web3(this.metamaskController.networkController._provider);
 
-    const initState = props.initState || {};
+    const initState = props.initState || {isInitProcessFinalized: false};
 
     const currentNetworkId = this.metamaskController.networkController.getNetworkState() === 'loading' ? global.networks.main :
       this.metamaskController.networkController.getNetworkState();
@@ -212,6 +212,30 @@ export default class RifController {
     return Promise.resolve(this.unlocked);
   }
 
+  finalizeInitProcess () {
+    const state = this.store.getState();
+    state.isInitProcessFinalized = true;
+    this.store.updateState(state);
+    return Promise.resolve();
+  }
+
+  isInitProcessFinalized () {
+    const state = this.store.getState();
+    return Promise.resolve(state.isInitProcessFinalized);
+  }
+
+  setUsingHardwareWallet (using = true) {
+    const state = this.store.getState();
+    state.usingHardwareWallet = using;
+    this.store.updateState(state);
+    return Promise.resolve();
+  }
+
+  isUsingHardwareWallet () {
+    const state = this.store.getState();
+    return Promise.resolve(state.usingHardwareWallet);
+  }
+
   /**
    * This method publishes all the operations available to call from the ui for RifController
    * and all it's members.
@@ -226,6 +250,10 @@ export default class RifController {
       cleanStore: bindOperation(this.cleanStore, this),
       enabled: bindOperation(this.enabled, this),
       walletUnlocked: bindOperation(this.walletUnlocked, this),
+      isInitProcessFinalized: bindOperation(this.isInitProcessFinalized, this),
+      finalizeInitProcess: bindOperation(this.finalizeInitProcess, this),
+      setUsingHardwareWallet: bindOperation(this.setUsingHardwareWallet, this),
+      isUsingHardwareWallet: bindOperation(this.isUsingHardwareWallet, this),
     }
   }
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -239,6 +239,7 @@
     "Estimating transaction cost…": "Estimating transaction cost…",
     "No Network Found": "No Network Found",
     "Type a name": "Type a name",
-    "Select": "Select"
+    "Select": "Select",
+    "Not supported feature using hardware wallet": "Not supported feature using hardware wallet"
   }
 }

--- a/languages/es.json
+++ b/languages/es.json
@@ -240,6 +240,7 @@
     "Estimating transaction cost…": "Estimando costo de la  transacción…",
     "No Network Found": "Red no encontrada",
     "Type a name": "Escribe un nombre",
-    "Select": "Seleccione"
+    "Select": "Seleccione",
+    "Not supported feature using hardware wallet": "Funcionalidad no soportada utilizando wallet física"
   }
 }

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -113,12 +113,13 @@ function mapStateToProps (state) {
 }
 
 App.prototype.componentDidUpdate = function () {
-  this.setupLuminoDefaultCallbacks(this.props.dispatch);
-  this.updateInitProcessStatus();
+  this.setupLuminoDefaultCallbacks(this.props.dispatch)
+  this.updateStatusFlags()
 }
 
-App.prototype.updateInitProcessStatus = async function () {
+App.prototype.updateStatusFlags = async function () {
   await this.props.dispatch(rifActions.updateInitProcessStatus())
+  await this.props.dispatch(rifActions.updateUsingWalletStatus())
 }
 
 App.prototype.setupLuminoDefaultCallbacks = function (dispatch) {

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -108,11 +108,17 @@ function mapStateToProps (state) {
     selected,
     keyrings,
     luminoCallbacksRunning: state.appState.luminoCallbacksRunning,
+    isInitProcessFinalized: state.appState.isInitProcessFinalized,
   }
 }
 
 App.prototype.componentDidUpdate = function () {
   this.setupLuminoDefaultCallbacks(this.props.dispatch);
+  this.updateInitProcessStatus();
+}
+
+App.prototype.updateInitProcessStatus = async function () {
+  await this.props.dispatch(rifActions.updateInitProcessStatus())
 }
 
 App.prototype.setupLuminoDefaultCallbacks = function (dispatch) {
@@ -120,7 +126,6 @@ App.prototype.setupLuminoDefaultCallbacks = function (dispatch) {
     dispatch(rifActions.rifEnabled()).then(enabled => {
       if (enabled) {
         dispatch(rifActions.setupDefaultLuminoCallbacks());
-
       }
     });
   }
@@ -253,6 +258,11 @@ App.prototype.renderPrimary = function () {
   if (props.seedWords) {
     log.debug('rendering seed words')
     return h(HDCreateVaultComplete, {key: 'HDCreateVaultComplete'})
+  }
+
+  if (!this.props.isInitProcessFinalized) {
+    log.debug('rendering hardware wallet menu screen')
+    return h(ConnectHardwareForm, {key: 'hardware-wallets-menu'})
   }
 
   // show current view

--- a/old-ui/app/components/connect-hardware/account-list.js
+++ b/old-ui/app/components/connect-hardware/account-list.js
@@ -133,7 +133,7 @@ class AccountList extends Component {
           type="default"
           large={true}
           className="new-account-connect-form__button btn-violet"
-          onClick={this.props.onCancel.bind(this)}
+          onClick={this.props.onCancel.bind(this, this.props.device)}
         >Cancel</Button>
         <Button
           type="primary"

--- a/old-ui/app/components/connect-hardware/connect-screen.js
+++ b/old-ui/app/components/connect-hardware/connect-screen.js
@@ -18,6 +18,9 @@ class ConnectScreen extends Component {
     static propTypes = {
         connectToHardwareWallet: PropTypes.func.isRequired,
         browserSupported: PropTypes.bool.isRequired,
+        goHome: PropTypes.func,
+        isInitProcessFinalized: PropTypes.bool,
+        finalizeInitProcess: PropTypes.func,
     }
 
     connect = () => {
@@ -109,10 +112,20 @@ class ConnectScreen extends Component {
             <div className="hw-connect__get-hw">
                 <p className="hw-connect__get-hw__msg">Don’t have a hardware wallet?</p>
                 {this.getAffiliateLinks()}
+                {this.getGoToHomeInitSection()}
             </div>
         )
     }
 
+    getGoToHomeInitSection () {
+      return !this.props.isInitProcessFinalized ? (<p className="hw-connect__get-hw__msg">
+        Or you can skip this and go directly to the home page
+        <span className="hw-connect__get-hw__link" onClick={async () => {
+          await this.props.finalizeInitProcess();
+          await this.props.goHome();
+        }}> here</span>
+      </p>) : null;
+    }
 
     scrollToTutorial = (e) => {
       if (this.referenceNode) this.referenceNode.scrollIntoView({behavior: 'smooth'})

--- a/old-ui/app/components/connect-hardware/forget-screen.js
+++ b/old-ui/app/components/connect-hardware/forget-screen.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from '../../../../ui/app/actions'
+import rifActions from '../../../../ui/app/rif/actions'
 import { capitalizeFirstLetter } from '../../../../app/scripts/lib/util'
 
 class ForgetDeviceScreen extends Component {
@@ -18,6 +19,7 @@ class ForgetDeviceScreen extends Component {
 		showConnectHWWalletPage: PropTypes.func,
 		forgetDevice: PropTypes.func,
 		goHome: PropTypes.func,
+    setUsingHardwareWallet: PropTypes.func,
 	}
 
 	render () {
@@ -55,6 +57,7 @@ class ForgetDeviceScreen extends Component {
 							accounts: [],
 							unlocked: false,
 						})
+            this.props.setUsingHardwareWallet(false);
 					})
 					.catch(e => {
 						this.setState({ error: (e.message || e.toString()) })
@@ -79,6 +82,7 @@ const mapDispatchToProps = dispatch => {
     showConnectHWWalletPage: () => dispatch(actions.showConnectHWWalletPage()),
     forgetDevice: (device, clearAccounts) => dispatch(actions.forgetDevice(device, clearAccounts)),
     goHome: () => dispatch(actions.goHome()),
+    setUsingHardwareWallet: (using) => dispatch(rifActions.setUsingHardwareWallet(using)),
   }
 }
 

--- a/old-ui/app/components/connect-hardware/index.js
+++ b/old-ui/app/components/connect-hardware/index.js
@@ -310,6 +310,7 @@ ConnectHardwareForm.propTypes = {
   customHdPaths: PropTypes.object,
   finalizeInitProcess: PropTypes.func,
   isInitProcessFinalized: PropTypes.func,
+  setUsingHardwareWallet: PropTypes.func,
 }
 
 const mapStateToProps = state => {

--- a/old-ui/app/components/connect-hardware/index.js
+++ b/old-ui/app/components/connect-hardware/index.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import actions from '../../../../ui/app/actions'
+import rifActions from '../../../../ui/app/rif/actions'
 import ConnectScreen from './connect-screen'
 import AccountList from './account-list'
 import { formatBalance } from '../../util'
@@ -10,19 +11,30 @@ import { PLATFORM_FIREFOX } from '../../../../app/scripts/lib/enums'
 import { getMetaMaskAccounts } from '../../../../ui/app/selectors'
 import { LEDGER, TREZOR } from './enum'
 
+const initialState = {
+  error: null,
+  selectedAccount: null,
+  selectedAccounts: [],
+  accounts: [],
+  browserSupported: true,
+  unlocked: false,
+  device: null,
+  isInitProcessFinalized: false,
+};
+
 class ConnectHardwareForm extends Component {
+
   constructor (props, context) {
     super(props)
+    this.state = initialState;
+    this.initialize();
+  }
+
+  initialize () {
     this.timerID = null
-    this.state = {
-      error: null,
-      selectedAccount: null,
-      selectedAccounts: [],
-      accounts: [],
-      browserSupported: true,
-      unlocked: false,
-      device: null,
-    }
+    this.props.isInitProcessFinalized().then(isInitProcessFinalized => {
+      this.setState({isInitProcessFinalized})
+    });
   }
 
   componentWillReceiveProps (nextProps) {
@@ -154,7 +166,14 @@ class ConnectHardwareForm extends Component {
   }
 
   onForgetDevice = (device) => {
-    this.props.showForgetDevicePage(device)
+    if (this.state.isInitProcessFinalized) {
+      this.props.showForgetDevicePage(device)
+    } else {
+      this.props.forgetDevice(device, true);
+      this.setState(initialState);
+      this.initialize();
+      this.props.setUsingHardwareWallet(false);
+    }
   }
 
   onUnlockAccount = (device) => {
@@ -165,7 +184,9 @@ class ConnectHardwareForm extends Component {
 
     this.unlockHardwareWalletAccounts(this.state.selectedAccounts, device)
     .then(_ => {
+      this.props.finalizeInitProcess();
       this.props.goHome()
+      this.props.setUsingHardwareWallet(true);
     })
   }
 
@@ -181,8 +202,15 @@ class ConnectHardwareForm extends Component {
     }, Promise.resolve())
   }
 
-  onCancel = () => {
-    this.props.goHome()
+  onCancel = (device) => {
+    if (this.state.isInitProcessFinalized) {
+      this.props.goHome()
+      console.log('GOING HOMEEEEEEEEEEEEEEEEEEEEEEE');
+    } else {
+      this.props.forgetDevice(device, true);
+      this.setState(initialState);
+      this.initialize();
+    }
   }
 
   renderError () {
@@ -197,6 +225,9 @@ class ConnectHardwareForm extends Component {
         <ConnectScreen
           connectToHardwareWallet={this.connectToHardwareWallet}
           browserSupported={this.state.browserSupported}
+          goHome={this.props.goHome}
+          isInitProcessFinalized={this.state.isInitProcessFinalized}
+          finalizeInitProcess={this.props.finalizeInitProcess}
         />
       )
     }
@@ -221,15 +252,19 @@ class ConnectHardwareForm extends Component {
   }
 
   render () {
+    let backButton = null;
+    if (this.state.isInitProcessFinalized) {
+      backButton = (<i className="fa fa-arrow-left fa-lg cursor-pointer"
+                       onClick={() => this.props.goHome() }
+                       style={{
+                         position: 'absolute',
+                         left: '30px',
+                       }}/>);
+    }
     return (
       <div style={{width: '100%'}}>
         <div className="section-title flex-row flex-center">
-          <i className="fa fa-arrow-left fa-lg cursor-pointer"
-            onClick={() => this.props.goHome() }
-            style={{
-              position: 'absolute',
-              left: '30px',
-          }}/>
+          {backButton}
           <h2>Connect to hardware wallet</h2>
         </div>
         <div style={{overflowY: 'auto', height: '482px'}}>
@@ -273,6 +308,8 @@ ConnectHardwareForm.propTypes = {
   address: PropTypes.string,
   defaultHdPaths: PropTypes.object,
   customHdPaths: PropTypes.object,
+  finalizeInitProcess: PropTypes.func,
+  isInitProcessFinalized: PropTypes.func,
 }
 
 const mapStateToProps = state => {
@@ -320,6 +357,9 @@ const mapDispatchToProps = dispatch => {
     showForgetDevicePage: (device) => dispatch(actions.showForgetDevicePage(device)),
     showAlert: (msg) => dispatch(actions.showAlert(msg)),
     hideAlert: () => dispatch(actions.hideAlert()),
+    finalizeInitProcess: () => dispatch(rifActions.finalizeInitProcess()),
+    isInitProcessFinalized: () => dispatch(rifActions.isInitProcessFinalized()),
+    setUsingHardwareWallet: (using) => dispatch(rifActions.setUsingHardwareWallet(using)),
   }
 }
 

--- a/old-ui/app/css/index.css
+++ b/old-ui/app/css/index.css
@@ -459,6 +459,7 @@ p.buy-option {
   height: 80px;
   background: var(--primary-color);
   font-family: var(--primary-font);
+  color: white;
 }
 
 .trash:after {
@@ -1211,4 +1212,10 @@ input[disabled],textarea[disabled] {
   height: 32px;
   width: 100%;
   margin-bottom: 20px;
+}
+
+.hw-connect__connect-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -878,6 +878,9 @@ function reduceApp (state, action) {
     case rifActions.LUMINO_CALLBACKS_RUNNING:
       return rifReducers.luminoCallbacksRunning(appState, action)
 
+    case rifActions.INIT_PROCESS_FINALIZED:
+      return rifReducers.isInitProcessFinalized(appState, action)
+
     default:
       return appState
   }

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -881,6 +881,9 @@ function reduceApp (state, action) {
     case rifActions.INIT_PROCESS_FINALIZED:
       return rifReducers.isInitProcessFinalized(appState, action)
 
+    case rifActions.USING_HARDWARE_WALLET:
+      return rifReducers.isUsingHardwareWallet(appState, action)
+
     default:
       return appState
   }

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -17,6 +17,7 @@ const rifActions = {
   RIF_LANDING_PAGE: 'RIF_LANDING_PAGE',
   LUMINO_CALLBACKS_RUNNING: 'LUMINO_CALLBACKS_RUNNING',
   INIT_PROCESS_FINALIZED: 'INIT_PROCESS_FINALIZED',
+  USING_HARDWARE_WALLET: 'USING_HARDWARE_WALLET',
   setBackgroundConnection,
   // RNS
   checkDomainAvailable,
@@ -86,6 +87,7 @@ const rifActions = {
   isInitProcessFinalized,
   setUsingHardwareWallet,
   isUsingHardwareWallet,
+  updateUsingWalletStatus,
 }
 
 let background = null;
@@ -1285,7 +1287,7 @@ function finalizeInitProcess () {
           handleError(error, dispatch);
           return reject(error);
         }
-        dispatch(setInitProcessFinalized(true));
+        dispatch(triggerInitProcessFinalizedActionUpdate(true));
         return resolve();
       });
     });
@@ -1297,10 +1299,10 @@ function updateInitProcessStatus () {
     return new Promise((resolve, reject) => {
       background.rif.isInitProcessFinalized((error, finalized) => {
         if (error) {
-          dispatch(setInitProcessFinalized(false));
+          dispatch(triggerInitProcessFinalizedActionUpdate(false));
           return reject(error);
         }
-        dispatch(setInitProcessFinalized(finalized));
+        dispatch(triggerInitProcessFinalizedActionUpdate(finalized));
         return resolve(finalized);
       });
     });
@@ -1308,10 +1310,17 @@ function updateInitProcessStatus () {
 }
 
 
-function setInitProcessFinalized (finalized) {
+function triggerInitProcessFinalizedActionUpdate (finalized) {
   return {
     type: rifActions.INIT_PROCESS_FINALIZED,
     data: finalized,
+  }
+}
+
+function triggerIsUsingHardwareWalletActionUpdate (using = true) {
+  return {
+    type: rifActions.USING_HARDWARE_WALLET,
+    data: using,
   }
 }
 
@@ -1337,6 +1346,7 @@ function setUsingHardwareWallet (using = true) {
           handleError(error, dispatch);
           return reject(error);
         }
+        dispatch(triggerIsUsingHardwareWalletActionUpdate(using));
         return resolve();
       });
     });
@@ -1351,6 +1361,21 @@ function isUsingHardwareWallet () {
           handleError(error, dispatch);
           return reject(error);
         }
+        return resolve(using);
+      });
+    });
+  };
+}
+
+function updateUsingWalletStatus () {
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.rif.isUsingHardwareWallet((error, using) => {
+        if (error) {
+          dispatch(triggerIsUsingHardwareWalletActionUpdate(false));
+          return reject(error);
+        }
+        dispatch(triggerIsUsingHardwareWalletActionUpdate(using));
         return resolve(using);
       });
     });

--- a/ui/app/rif/actions/index.js
+++ b/ui/app/rif/actions/index.js
@@ -16,6 +16,7 @@ const rifActions = {
   NAVIGATE_TO: 'NAVIGATE_TO',
   RIF_LANDING_PAGE: 'RIF_LANDING_PAGE',
   LUMINO_CALLBACKS_RUNNING: 'LUMINO_CALLBACKS_RUNNING',
+  INIT_PROCESS_FINALIZED: 'INIT_PROCESS_FINALIZED',
   setBackgroundConnection,
   // RNS
   checkDomainAvailable,
@@ -80,6 +81,11 @@ const rifActions = {
   changeLanguage,
   getCurrentLanguage,
   getAvailableLanguages,
+  finalizeInitProcess,
+  updateInitProcessStatus,
+  isInitProcessFinalized,
+  setUsingHardwareWallet,
+  isUsingHardwareWallet,
 }
 
 let background = null;
@@ -1056,7 +1062,7 @@ function showRifLandingPage () {
       screenTitle: 'My Domains',
       showTitle: true,
       tabIndex: 0,
-    }
+    },
   };
   pushScreenToNavigationStack('rif.landingPage', params);
   return {
@@ -1267,6 +1273,86 @@ function getAvailableLanguages () {
     return new Promise((resolve) => {
       const availableLanguages = Object.keys(languages).map(key => languages[key]);
       resolve(availableLanguages);
+    });
+  };
+}
+
+function finalizeInitProcess () {
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.rif.finalizeInitProcess((error) => {
+        if (error) {
+          handleError(error, dispatch);
+          return reject(error);
+        }
+        dispatch(setInitProcessFinalized(true));
+        return resolve();
+      });
+    });
+  };
+}
+
+function updateInitProcessStatus () {
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.rif.isInitProcessFinalized((error, finalized) => {
+        if (error) {
+          dispatch(setInitProcessFinalized(false));
+          return reject(error);
+        }
+        dispatch(setInitProcessFinalized(finalized));
+        return resolve(finalized);
+      });
+    });
+  };
+}
+
+
+function setInitProcessFinalized (finalized) {
+  return {
+    type: rifActions.INIT_PROCESS_FINALIZED,
+    data: finalized,
+  }
+}
+
+function isInitProcessFinalized () {
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.rif.isInitProcessFinalized((error, finalized) => {
+        if (error) {
+          handleError(error, dispatch);
+          return reject(error);
+        }
+        return resolve(finalized);
+      });
+    });
+  };
+}
+
+function setUsingHardwareWallet (using = true) {
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.rif.setUsingHardwareWallet(using, (error) => {
+        if (error) {
+          handleError(error, dispatch);
+          return reject(error);
+        }
+        return resolve();
+      });
+    });
+  };
+}
+
+function isUsingHardwareWallet () {
+  return (dispatch) => {
+    return new Promise((resolve, reject) => {
+      background.rif.isUsingHardwareWallet((error, using) => {
+        if (error) {
+          handleError(error, dispatch);
+          return reject(error);
+        }
+        return resolve(using);
+      });
     });
   };
 }

--- a/ui/app/rif/components/lumino/open-channel/index.js
+++ b/ui/app/rif/components/lumino/open-channel/index.js
@@ -30,8 +30,7 @@ class OpenChannel extends Component {
     getTokens: PropTypes.func,
     option: PropTypes.object,
     domainNotExists: PropTypes.func,
-    t: PropTypes.func,
-    isUsingHardwareWallet: PropTypes.func,
+    t: PropTypes.func
   }
 
   constructor (props) {
@@ -63,10 +62,7 @@ class OpenChannel extends Component {
       selectedToken: selectedToken,
       loading: false,
       loadingMessage: t('Please Wait...'),
-      isUsingHardwareWallet: false,
     };
-    this.props.isUsingHardwareWallet()
-      .then(isUsingHardwareWallet => this.setState({isUsingHardwareWallet}));
   }
 
   changeDestination (event) {
@@ -92,7 +88,7 @@ class OpenChannel extends Component {
   }
 
   getBody () {
-    const {tokensOptions, selectedToken, loading, isUsingHardwareWallet} = this.state;
+    const {tokensOptions, selectedToken, loading} = this.state;
     const {t} = this.props;
 
     if (loading) {
@@ -144,11 +140,8 @@ class OpenChannel extends Component {
       return getLoader(this.state.loadingMessage);
     }
 
-    const hardwareMessage = isUsingHardwareWallet ? (<div className="block-ui-message"><div>Not supported using hardware wallet</div></div>) : null;
-
     return (
-      <div className={isUsingHardwareWallet ? 'block-ui' : ''}>
-        {hardwareMessage}
+      <div>
         {(!this.props.tokenAddress) &&
         <div id="comboChainAddresses" className="select-token-container">
           <Select
@@ -165,7 +158,7 @@ class OpenChannel extends Component {
         }
         <div className="form-segment">
           <input className="domain-address-input domain-address-input--open-channel" type="text"
-                 placeholder={t('Enter address / domain')}
+                 placeholder={t("Enter address / domain")}
                  onChange={(event) => this.changeDestination(event)}/>
           <span>
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -180,7 +173,7 @@ class OpenChannel extends Component {
         <div className="form-segment">
           <input className="amount-input amount-input--open-channel"
                  type="text"
-                 placeholder={t('{{tokenSymbol}} Amount', {tokenSymbol: this.state.selectedToken.symbol})}
+                 placeholder={t("{{tokenSymbol}} Amount", {tokenSymbol: this.state.selectedToken.symbol})}
                  onKeyDown={event => this.validateAmount(event)}
                  onChange={event => this.changeAmount(event)}/>
         </div>
@@ -343,7 +336,6 @@ function mapDispatchToProps (dispatch) {
     createDeposit: (partner, tokenAddress, tokenNetworkAddress, channelIdentifier, amount, callbackHandlers) =>
       dispatch(rifActions.createDeposit(partner, tokenAddress, tokenNetworkAddress, channelIdentifier, amount, callbackHandlers)),
     domainNotExists: (domainName) => dispatch(rifActions.checkDomainAvailable(domainName)),
-    isUsingHardwareWallet: () => dispatch(rifActions.isUsingHardwareWallet()),
   };
 }
 

--- a/ui/app/rif/components/lumino/open-channel/index.js
+++ b/ui/app/rif/components/lumino/open-channel/index.js
@@ -11,7 +11,7 @@ import {DEFAULT_ICON} from '../../../constants';
 import {FontAwesomeIcon} from '@fortawesome/react-fontawesome';
 import {getLoader} from '../../../utils/components';
 import ethUtils from 'ethereumjs-util';
-import {withTranslation} from "react-i18next";
+import {withTranslation} from 'react-i18next';
 
 class OpenChannel extends Component {
 
@@ -30,7 +30,8 @@ class OpenChannel extends Component {
     getTokens: PropTypes.func,
     option: PropTypes.object,
     domainNotExists: PropTypes.func,
-    t: PropTypes.func
+    t: PropTypes.func,
+    isUsingHardwareWallet: PropTypes.func,
   }
 
   constructor (props) {
@@ -62,7 +63,10 @@ class OpenChannel extends Component {
       selectedToken: selectedToken,
       loading: false,
       loadingMessage: t('Please Wait...'),
+      isUsingHardwareWallet: false,
     };
+    this.props.isUsingHardwareWallet()
+      .then(isUsingHardwareWallet => this.setState({isUsingHardwareWallet}));
   }
 
   changeDestination (event) {
@@ -88,7 +92,7 @@ class OpenChannel extends Component {
   }
 
   getBody () {
-    const {tokensOptions, selectedToken, loading} = this.state;
+    const {tokensOptions, selectedToken, loading, isUsingHardwareWallet} = this.state;
     const {t} = this.props;
 
     if (loading) {
@@ -108,7 +112,7 @@ class OpenChannel extends Component {
     }
 
     const selectOption = (props) => {
-      const {option, t} = props;
+      const {option} = props;
       const icon = option.icon ? option.icon : DEFAULT_ICON;
       return (
         <div
@@ -140,8 +144,11 @@ class OpenChannel extends Component {
       return getLoader(this.state.loadingMessage);
     }
 
+    const hardwareMessage = isUsingHardwareWallet ? (<div className="block-ui-message"><div>Not supported using hardware wallet</div></div>) : null;
+
     return (
-      <div>
+      <div className={isUsingHardwareWallet ? 'block-ui' : ''}>
+        {hardwareMessage}
         {(!this.props.tokenAddress) &&
         <div id="comboChainAddresses" className="select-token-container">
           <Select
@@ -158,7 +165,7 @@ class OpenChannel extends Component {
         }
         <div className="form-segment">
           <input className="domain-address-input domain-address-input--open-channel" type="text"
-                 placeholder={t("Enter address / domain")}
+                 placeholder={t('Enter address / domain')}
                  onChange={(event) => this.changeDestination(event)}/>
           <span>
             <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -173,7 +180,7 @@ class OpenChannel extends Component {
         <div className="form-segment">
           <input className="amount-input amount-input--open-channel"
                  type="text"
-                 placeholder={t("{{tokenSymbol}} Amount", {tokenSymbol: this.state.selectedToken.symbol})}
+                 placeholder={t('{{tokenSymbol}} Amount', {tokenSymbol: this.state.selectedToken.symbol})}
                  onKeyDown={event => this.validateAmount(event)}
                  onChange={event => this.changeAmount(event)}/>
         </div>
@@ -336,6 +343,7 @@ function mapDispatchToProps (dispatch) {
     createDeposit: (partner, tokenAddress, tokenNetworkAddress, channelIdentifier, amount, callbackHandlers) =>
       dispatch(rifActions.createDeposit(partner, tokenAddress, tokenNetworkAddress, channelIdentifier, amount, callbackHandlers)),
     domainNotExists: (domainName) => dispatch(rifActions.checkDomainAvailable(domainName)),
+    isUsingHardwareWallet: () => dispatch(rifActions.isUsingHardwareWallet()),
   };
 }
 

--- a/ui/app/rif/pages/common-style-pages.css
+++ b/ui/app/rif/pages/common-style-pages.css
@@ -57,3 +57,32 @@
   margin-bottom: 20px;
   font-weight: 300;
 }
+
+.block-ui::before {
+  width: 100vh;
+  height: 100vh;
+  z-index: 1020;
+  background: rgba(255, 255, 255, 0.8);
+  content: " ";
+  position: absolute;
+}
+
+.block-ui-message {
+  width: 100%;
+  height: 100%;
+  z-index: 1021;
+  background: transparent;
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.block-ui-message>div {
+  color: var(--primary-color);
+  font-weight: bold;
+  text-transform: uppercase;
+  padding: 1em;
+  text-align: center;
+  font-size: 0.8em;
+}

--- a/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
+++ b/ui/app/rif/pages/domainsDetailPage/domainDetailActive/domainDetailActive.js
@@ -124,6 +124,7 @@ class DomainsDetailActiveScreen extends Component {
     isLuminoNode: PropTypes.func,
     showPay: PropTypes.func,
     getResolver: PropTypes.func,
+    isUsingHardwareWallet: PropTypes.bool,
   }
 
   constructor (props) {
@@ -150,11 +151,12 @@ class DomainsDetailActiveScreen extends Component {
       resolvers: [],
       isLuminoNode: false,
       resolver: {},
+      isUsingHardwareWallet: false,
     };
   }
 
   render () {
-    const { domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, newChainAddresses, newSubdomains, showPay } = this.props;
+    const { domainName, content, expirationDate, autoRenew, ownerAddress, isOwner, isRifStorage, newChainAddresses, newSubdomains, showPay, isUsingHardwareWallet } = this.props;
     const {resolvers, isLuminoNode, resolver} = this.state;
     const selectedResolverAddress = (resolver && resolver.address) ? resolver.address.toLowerCase() : '';
     const domainInfo = {
@@ -168,6 +170,16 @@ class DomainsDetailActiveScreen extends Component {
       content,
       selectedResolverAddress,
     };
+
+    const luminoNetworks = !isUsingHardwareWallet ? (
+      <LuminoNetworkChannels
+        isOwner={isOwner}
+        paginationSize={PAGINATION_DEFAULT_SIZE}
+        classes={styles.LuminoNetworkChannels}
+        pageName={pageNames.rns.domainsDetail}
+        tabIndex={0}
+      />
+    ) : null;
 
     return (
       <div className="domain-detail">
@@ -223,13 +235,7 @@ class DomainsDetailActiveScreen extends Component {
             }}
             pageName={pageNames.rns.domainsDetail}
           />
-          <LuminoNetworkChannels
-            isOwner={isOwner}
-            paginationSize={PAGINATION_DEFAULT_SIZE}
-            classes={styles.LuminoNetworkChannels}
-            pageName={pageNames.rns.domainsDetail}
-            tabIndex={0}
-          />
+          {luminoNetworks}
         </div>
       </div>
     );
@@ -255,6 +261,7 @@ function mapStateToProps (state) {
     newSubdomains: params.newSubdomains || details.newSubdomains || [],
     disableResolvers: details.disableResolvers,
     domain: domain,
+    isUsingHardwareWallet: state.appState.isUsingHardwareWallet,
   }
 }
 

--- a/ui/app/rif/pages/lumino/index.js
+++ b/ui/app/rif/pages/lumino/index.js
@@ -31,7 +31,8 @@ class LuminoHome extends Component {
     getLuminoNetworks: PropTypes.func,
     currentAddress: PropTypes.string,
     navigateTo: PropTypes.func,
-    t: PropTypes.func
+    t: PropTypes.func,
+    isUsingHardwareWallet: PropTypes.func,
   }
 
   constructor (props) {
@@ -45,7 +46,10 @@ class LuminoHome extends Component {
         withChannels: [],
         withoutChannels: [],
       },
+      isUsingHardwareWallet: false,
     }
+    this.props.isUsingHardwareWallet()
+      .then(isUsingHardwareWallet => this.setState({isUsingHardwareWallet}));
   }
 
   componentDidMount () {
@@ -93,7 +97,7 @@ class LuminoHome extends Component {
   }
 
   render () {
-    const {networks, filteredNetworks} = this.state;
+    const {networks, filteredNetworks, isUsingHardwareWallet} = this.state;
     const {t} = this.props;
     const myNetworks = this.getNetworkItems(filteredNetworks.withChannels)
     const otherNetworks = this.getNetworkItems(filteredNetworks.withoutChannels)
@@ -106,8 +110,12 @@ class LuminoHome extends Component {
       Header: 'Content',
       accessor: 'content',
     }];
+
+    const hardwareMessage = isUsingHardwareWallet ? (<div className="block-ui-message"><div>Not supported using hardware wallet</div></div>) : null;
+
     return (
-      <div className="rif-home-body">
+      <div className={'rif-home-body' + (isUsingHardwareWallet ? ' block-ui' : '')}>
+        {hardwareMessage}
         <SearchLuminoNetworks data={combinedNetworks} setFilteredNetworks={this.setFilteredNetworks}/>
         {!itemsWereFiltered && <h2 className="page-title">{t('Lumino networks directory')}</h2>}
         {itemsWereFiltered &&
@@ -169,6 +177,7 @@ function mapDispatchToProps (dispatch) {
         },
       }));
     },
+    isUsingHardwareWallet: () => dispatch(rifActions.isUsingHardwareWallet()),
   }
 }
 

--- a/ui/app/rif/pages/lumino/index.js
+++ b/ui/app/rif/pages/lumino/index.js
@@ -6,7 +6,8 @@ import LuminoNetworkItem from '../../components/LuminoNetworkItem';
 import {pageNames} from '../names';
 import {GenericTable, OpenChannel} from '../../components';
 import SearchLuminoNetworks from '../../components/searchLuminoNetworks';
-import {withTranslation} from "react-i18next";
+import {withTranslation} from 'react-i18next';
+import {getBlockUiMessage} from '../../utils/components';
 
 const styles = {
   myLuminoNetwork: {
@@ -32,7 +33,7 @@ class LuminoHome extends Component {
     currentAddress: PropTypes.string,
     navigateTo: PropTypes.func,
     t: PropTypes.func,
-    isUsingHardwareWallet: PropTypes.func,
+    isUsingHardwareWallet: PropTypes.bool,
   }
 
   constructor (props) {
@@ -46,17 +47,14 @@ class LuminoHome extends Component {
         withChannels: [],
         withoutChannels: [],
       },
-      isUsingHardwareWallet: false,
     }
-    this.props.isUsingHardwareWallet()
-      .then(isUsingHardwareWallet => this.setState({isUsingHardwareWallet}));
   }
 
   componentDidMount () {
     this.getLuminoNetworks();
   }
 
-  async getLuminoNetworks() {
+  async getLuminoNetworks () {
     const {getLuminoNetworks, currentAddress} = this.props;
     const networks = await getLuminoNetworks(currentAddress);
     if (networks && networks.withChannels.length || networks.withoutChannels.length) {
@@ -97,8 +95,8 @@ class LuminoHome extends Component {
   }
 
   render () {
-    const {networks, filteredNetworks, isUsingHardwareWallet} = this.state;
-    const {t} = this.props;
+    const {networks, filteredNetworks} = this.state;
+    const {t, isUsingHardwareWallet} = this.props;
     const myNetworks = this.getNetworkItems(filteredNetworks.withChannels)
     const otherNetworks = this.getNetworkItems(filteredNetworks.withoutChannels)
     const combinedNetworks = [...networks.withChannels, ...networks.withoutChannels];
@@ -111,7 +109,7 @@ class LuminoHome extends Component {
       accessor: 'content',
     }];
 
-    const hardwareMessage = isUsingHardwareWallet ? (<div className="block-ui-message"><div>Not supported using hardware wallet</div></div>) : null;
+    const hardwareMessage = isUsingHardwareWallet ? getBlockUiMessage(t('Not supported feature using hardware wallet')) : null;
 
     return (
       <div className={'rif-home-body' + (isUsingHardwareWallet ? ' block-ui' : '')}>
@@ -144,7 +142,7 @@ class LuminoHome extends Component {
             paginationSize={3}/>
         </div>
         }
-        <div  className="lumino-list-container">
+        <div className="lumino-list-container">
           <OpenChannel
             reloadChannels={() => this.getLuminoNetworks()}
             afterChannelCreated={() => this.getLuminoNetworks()}
@@ -158,6 +156,7 @@ class LuminoHome extends Component {
 function mapStateToProps (state) {
   return {
     currentAddress: state.metamask.selectedAddress.toLowerCase(),
+    isUsingHardwareWallet: state.appState.isUsingHardwareWallet,
   }
 }
 
@@ -177,7 +176,6 @@ function mapDispatchToProps (dispatch) {
         },
       }));
     },
-    isUsingHardwareWallet: () => dispatch(rifActions.isUsingHardwareWallet()),
   }
 }
 

--- a/ui/app/rif/pages/rns/subdomains/index.js
+++ b/ui/app/rif/pages/rns/subdomains/index.js
@@ -92,7 +92,8 @@ class Subdomains extends Component {
     isDomainOwner: PropTypes.bool,
     showConfigPage: PropTypes.func,
     getResolver: PropTypes.func,
-    t: PropTypes.func
+    t: PropTypes.func,
+    isUsingHardwareWallet: PropTypes.bool,
   }
 
   constructor (props) {
@@ -185,10 +186,20 @@ class Subdomains extends Component {
   }
 
   render () {
-    const {subdomain, domainName, newChainAddresses, isOwner, isDomainOwner} = this.props;
+    const {subdomain, domainName, newChainAddresses, isOwner, isDomainOwner, isUsingHardwareWallet} = this.props;
     const updatedChainAddresses = newChainAddresses || [];
     const displayName = `${subdomain.name}.${domainName}`
     const {resolvers} = this.state;
+
+    const luminoNetworks = !isUsingHardwareWallet ? (
+      <LuminoNetworkChannels
+        isOwner={isOwner}
+        paginationSize={PAGINATION_DEFAULT_SIZE}
+        classes={styles.luminoNetworkChannels}
+        pageName={pageNames.rns.subdomains}
+      />
+    ) : null;
+
     return (
       <div className="body subdomain-page">
         <DomainHeader
@@ -242,12 +253,7 @@ class Subdomains extends Component {
           />
         </div>
         }
-        <LuminoNetworkChannels
-          isOwner={isOwner}
-          paginationSize={PAGINATION_DEFAULT_SIZE}
-          classes={styles.luminoNetworkChannels}
-          pageName={pageNames.rns.subdomains}
-        />
+        {luminoNetworks}
       </div>
     );
   }
@@ -258,6 +264,7 @@ function mapStateToProps (state) {
   return {
     ...params,
     isOwner: state.metamask.selectedAddress.toLowerCase() === params.subdomain.ownerAddress.toLowerCase(),
+    isUsingHardwareWallet: state.appState.isUsingHardwareWallet,
   }
 }
 

--- a/ui/app/rif/reducers/index.js
+++ b/ui/app/rif/reducers/index.js
@@ -65,6 +65,12 @@ function isInitProcessFinalized (appState, action) {
   });
 }
 
+function isUsingHardwareWallet (appState, action) {
+  return extend(appState, {
+    isUsingHardwareWallet: action.data,
+  });
+}
+
 export const rifReducers = {
   navigateTo,
   showMenu,
@@ -72,4 +78,5 @@ export const rifReducers = {
   landingPage,
   luminoCallbacksRunning,
   isInitProcessFinalized,
+  isUsingHardwareWallet,
 }

--- a/ui/app/rif/reducers/index.js
+++ b/ui/app/rif/reducers/index.js
@@ -59,10 +59,17 @@ function luminoCallbacksRunning (appState, action) {
   });
 }
 
+function isInitProcessFinalized (appState, action) {
+  return extend(appState, {
+    isInitProcessFinalized: action.data,
+  });
+}
+
 export const rifReducers = {
   navigateTo,
   showMenu,
   showModal,
   landingPage,
   luminoCallbacksRunning,
+  isInitProcessFinalized,
 }

--- a/ui/app/rif/utils/components.js
+++ b/ui/app/rif/utils/components.js
@@ -8,3 +8,7 @@ export function getLoader (message) {
     </div>
   );
 }
+
+export function getBlockUiMessage (message) {
+  return (<div className="block-ui-message"><div>{message}</div></div>);
+}

--- a/ui/app/rif/utils/utils.js
+++ b/ui/app/rif/utils/utils.js
@@ -1,6 +1,5 @@
 // Constant names, if you want to add a new token (icon), just go to constant.js and add one to the array, then add it to getNameTokenForIcon
 import {SLIP_ADDRESSES, PRIORITY_SLIP_ADDRESSES} from '../constants/slipAddresses'
-import React from 'react';
 import _ from 'lodash';
 
 const slipChainAddresses = [...PRIORITY_SLIP_ADDRESSES, ...SLIP_ADDRESSES]


### PR DESCRIPTION
In this PR we are:

- Adding the new home for nifty, the hardware wallet integration page is the new home
- Adding the ability to detect if the user is using a hardware wallet
- Adding the ability to block a page using a block ui
- Blocking lumino features when the user is using a hardware wallet

This affects the ui and service layers.

Here a demo of the home page:

![demo](https://user-images.githubusercontent.com/7540348/94704701-9215d400-0316-11eb-9fb4-8f4d7396ad75.gif)

Here some screenshots of lumino block:

![imagen](https://user-images.githubusercontent.com/7540348/94704892-c8ebea00-0316-11eb-9521-d55175941de1.png)

![imagen](https://user-images.githubusercontent.com/7540348/94704902-cc7f7100-0316-11eb-896e-02a91c57047b.png)

![imagen](https://user-images.githubusercontent.com/7540348/94704908-cf7a6180-0316-11eb-96b0-67d02efaac17.png)
