### PR TITLE
RLP-934 Only change configuration on regtest network, block in the other networks

### DIFF
--- a/app/scripts/controllers/rif/utils/general.js
+++ b/app/scripts/controllers/rif/utils/general.js
@@ -3,6 +3,10 @@ import {toChecksumAddress} from 'web3-utils';
 
 const nodeify = require('../../../lib/nodeify');
 
+export function isRskConfigurableNetwork (networkId) {
+  return global.networks.reg === networkId;
+}
+
 export function isRskNetwork (networkId) {
   return global.networks.main === networkId ||
     global.networks.test === networkId ||

--- a/old-ui/app/config.js
+++ b/old-ui/app/config.js
@@ -4,7 +4,7 @@ const Component = require('react').Component
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
 import PropTypes from 'prop-types'
-import {isRskNetwork} from '../../app/scripts/controllers/rif/utils/general';
+import {isRskConfigurableNetwork} from '../../app/scripts/controllers/rif/utils/general';
 import {withTranslation} from 'react-i18next';
 const actions = require('../../ui/app/actions')
 const rifActions = require('../../ui/app/rif/actions');
@@ -76,7 +76,7 @@ class ConfigScreen extends Component {
     }
 
     let rifConfiguration = null;
-    if (isRskNetwork(this.props.metamask.network)) {
+    if (isRskConfigurableNetwork(this.props.metamask.network)) {
       rifConfiguration = h('div', [
         h('p.config-title', this.props.t('RIF Configuration')),
         h('p.config-description', this.props.t('This is for rif configuration only.')),


### PR DESCRIPTION
### Introduction
This PR introduces the change to allow changing the configuration for RIF only when you are in RegTest network.

### Changes
* Changing the check on the configuration button to only appear when we are in a configurable rsk network

This affects only the ui layer.